### PR TITLE
Potential fix for code scanning alert no. 13: Missing regular expression anchor

### DIFF
--- a/internal/infra/downloader/youtube.go
+++ b/internal/infra/downloader/youtube.go
@@ -13,11 +13,11 @@ import (
 )
 
 var videoIDPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`youtube\.com/watch\?v=([\w-]{11})`),
-	regexp.MustCompile(`youtu\.be/([\w-]{11})`),
-	regexp.MustCompile(`youtube\.com/shorts/([\w-]{11})`),
-	regexp.MustCompile(`youtube\.com/embed/([\w-]{11})`),
-	regexp.MustCompile(`music\.youtube\.com/watch\?v=([\w-]{11})`),
+	regexp.MustCompile(`^https?://(?:www\.)?youtube\.com/watch\?v=([\w-]{11})`),
+	regexp.MustCompile(`^https?://(?:www\.)?youtu\.be/([\w-]{11})`),
+	regexp.MustCompile(`^https?://(?:www\.)?youtube\.com/shorts/([\w-]{11})`),
+	regexp.MustCompile(`^https?://(?:www\.)?youtube\.com/embed/([\w-]{11})`),
+	regexp.MustCompile(`^https?://music\.youtube\.com/watch\?v=([\w-]{11})`),
 }
 
 // YouTubeClient wraps the kkdai/youtube library for video metadata and stream fetching.


### PR DESCRIPTION
Potential fix for [https://github.com/teofanis/ybdownloader/security/code-scanning/13](https://github.com/teofanis/ybdownloader/security/code-scanning/13)

In general, to fix missing regular expression anchors when matching URLs, constrain the pattern so it matches the entire URL structure (or at least from the beginning) instead of any substring. This is usually done by adding `^` at the start, and optionally `$` at the end, and including an explicit scheme/domain structure so that untrusted surrounding text or different hosts cannot cause unintended matches.

For this specific code, the best fix without changing functionality is to tighten each pattern in `videoIDPatterns` so they match typical YouTube URLs from the start of the string, including the `http`/`https` scheme and optional `www.` where appropriate. This keeps the extraction logic the same (still using the first capturing group as the ID) while preventing matches in arbitrary positions or on non‑YouTube hosts. We should update all patterns in the slice, not just the `shorts` one, to maintain consistent behavior. All required imports (`regexp`) already exist; no new methods or types are needed—only the literal regex strings in `videoIDPatterns` (lines 15–21) need to be updated inside `internal/infra/downloader/youtube.go`.

Concretely:
- Add `^https?://` at the beginning of each pattern to ensure the match starts at the URL’s scheme.
- For domains where `www.` is used (plain `youtube.com` URLs), allow an optional `www\.` (`(?:www\.)?`) so both `https://youtube.com/...` and `https://www.youtube.com/...` are handled.
- For `youtu.be`, allow optional `www.` as well.
- Keep the capturing group `([\w-]{11})` unchanged so `ExtractVideoID` still returns the same ID.
- Optionally, add `$` at the end if you want to ensure nothing follows; I will not add `$` here to avoid breaking URLs with extra query parameters or fragments after the ID, but the critical problem (arbitrary host/position) is already fixed by anchoring at the beginning with the scheme and hostname.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
