### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: '1.25'
   NODE_VERSION: '24'


### PR DESCRIPTION
Potential fix for [https://github.com/teofanis/ybdownloader/security/code-scanning/7](https://github.com/teofanis/ybdownloader/security/code-scanning/7)

In general, the fix is to explicitly declare GITHUB_TOKEN permissions and restrict them to the minimum required. Since no job here writes to the repository or to other GitHub resources, the minimal reasonable permission is `contents: read`. This can be set once at the workflow root so it applies to all jobs.

The best fix without changing existing functionality is to add a `permissions:` block near the top of `.github/workflows/ci.yml`, alongside `name`, `on`, and `env`. For example, add:

```yaml
permissions:
  contents: read
```

between the `on:` block and `env:` block (lines 8–9 in the snippet). This ensures all jobs, including `build-check` on line 166 (the one flagged by CodeQL), will run with only read access to repository contents, resolving the warning while preserving current behavior. No additional methods, imports, or definitions are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
