### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/extension-release.yml
+++ b/.github/workflows/extension-release.yml
@@ -16,6 +16,8 @@ jobs:
   build:
     name: Build Extension
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/teofanis/ybdownloader/security/code-scanning/2](https://github.com/teofanis/ybdownloader/security/code-scanning/2)

In general, the problem is fixed by explicitly defining a `permissions` block either at the workflow root (applies to all jobs without their own block) or on the specific job flagged by CodeQL. The `permissions` should grant only what is needed. For this workflow, the `build` job only needs to read repository contents (for `actions/checkout`) and interact with artifacts; artifact upload does not require special repo-scoped permissions, so `contents: read` is sufficient. The `release` job already has `permissions: contents: write`, which is required to create a GitHub Release and upload assets.

The best minimal fix without changing behavior is to add a `permissions` block to the `build` job with `contents: read`. This leaves the existing `release` job permissions untouched and ensures `build` does not inherit broader repo defaults. Concretely, in `.github/workflows/extension-release.yml`, under `jobs: build: name: Build Extension`, insert:

```yaml
    permissions:
      contents: read
```

indented to align with `runs-on`. No imports or external dependencies are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
