### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/extension-ci.yml
+++ b/.github/workflows/extension-ci.yml
@@ -12,6 +12,9 @@ on:
       - "browser-extension/**"
       - ".github/workflows/extension-ci.yml"
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: browser-extension


### PR DESCRIPTION
Potential fix for [https://github.com/teofanis/ybdownloader/security/code-scanning/4](https://github.com/teofanis/ybdownloader/security/code-scanning/4)

In general, the fix is to explicitly set the `permissions` for the `GITHUB_TOKEN` to the minimal scope required by the workflow. Here, both jobs only need to check out code and run local Node.js commands, plus upload artifacts, which all work with `contents: read`. No step writes to the repo, issues, or pull requests.

The best minimal fix without changing functionality is to add a workflow-level `permissions` block right after the `name` (or after `on:`) so it applies to all jobs that don’t override it. In `.github/workflows/extension-ci.yml`, add:

```yaml
permissions:
  contents: read
```

near the top. No additional imports or actions are required; this is purely a YAML configuration change. Both `lint` and `build` jobs will then run with read-only repository contents permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
