### PR TITLE
chore: update Go version to 1.26 and adjust dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.25'
-  NODE_VERSION: '24'
+  GO_VERSION: "1.26"
+  NODE_VERSION: "24"
 
 jobs:
   # Go backend tests and linting
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install frontend dependencies
@@ -91,7 +91,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install frontend dependencies
@@ -122,7 +122,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
@@ -182,7 +182,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install Linux dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.7.2
+          version: v2.12.2
           args: --timeout=5m
 
   # Frontend tests and linting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,17 +3,17 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version tag (e.g., v1.0.0)'
+        description: "Version tag (e.g., v1.0.0)"
         required: true
 
 env:
-  GO_VERSION: '1.25'
-  NODE_VERSION: '24'
-  APP_NAME: 'ybdownloader'
+  GO_VERSION: "1.26"
+  NODE_VERSION: "24"
+  APP_NAME: "ybdownloader"
 
 permissions:
   contents: write
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install Wails
@@ -86,25 +86,25 @@ jobs:
           # Download appimagetool (Go/Wails binaries are self-contained, no need for linuxdeploy)
           wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
           chmod +x appimagetool-x86_64.AppImage
-          
+
           # Create AppDir structure
           mkdir -p AppDir/usr/bin
           mkdir -p AppDir/usr/share/applications
           mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
-          
+
           # Copy binary
           cp build/bin/${{ env.APP_NAME }}-linux-amd64 AppDir/usr/bin/${{ env.APP_NAME }}
           chmod +x AppDir/usr/bin/${{ env.APP_NAME }}
-          
+
           # Copy and update desktop file for AppImage (change Exec path)
           sed 's|/usr/bin/ybdownloader|ybdownloader|g' build/linux/ybdownloader.desktop > AppDir/usr/share/applications/ybdownloader.desktop
           cp AppDir/usr/share/applications/ybdownloader.desktop AppDir/ybdownloader.desktop
-          
+
           # Copy icon
           cp build/appicon.png AppDir/usr/share/icons/hicolor/256x256/apps/ybdownloader.png
           cp build/appicon.png AppDir/ybdownloader.png
           ln -sf ybdownloader.png AppDir/.DirIcon
-          
+
           # Create AppRun launcher script
           cat > AppDir/AppRun << 'EOF'
           #!/bin/bash
@@ -114,13 +114,13 @@ jobs:
           exec "${HERE}/usr/bin/ybdownloader" "$@"
           EOF
           chmod +x AppDir/AppRun
-          
+
           # Create AppImage using appimagetool (--appimage-extract-and-run for CI without FUSE)
           ARCH=x86_64 ./appimagetool-x86_64.AppImage --appimage-extract-and-run AppDir ${{ env.APP_NAME }}-linux-amd64.AppImage
-          
+
           # Move to build/bin
           mv ${{ env.APP_NAME }}-linux-amd64.AppImage build/bin/
-          
+
           # Cleanup
           rm -rf AppDir appimagetool-x86_64.AppImage
 
@@ -152,7 +152,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install Wails
@@ -163,17 +163,17 @@ jobs:
         run: |
           Write-Host "Installing NSIS via Chocolatey..."
           choco install nsis -y --no-progress
-          
+
           # Refresh environment to pick up new PATH entries from Chocolatey
           $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
-          
+
           # Add NSIS directories to GITHUB_PATH for subsequent steps
           $nsisDir = "C:\Program Files (x86)\NSIS"
           if (Test-Path $nsisDir) {
             Write-Host "Adding NSIS to GITHUB_PATH: $nsisDir"
             echo "$nsisDir" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           }
-          
+
           # Verify installation
           Write-Host "Verifying NSIS installation..."
           $nsisExe = "$nsisDir\makensis.exe"
@@ -205,15 +205,15 @@ jobs:
           # Extract only the numeric version part for NSIS (e.g., "1.0.0" from "1.0.0-beta.1")
           # NSIS expects a version like "1.0.0" that becomes "1.0.0.0"
           $nsisVersion = $version -replace "-.*$", ""
-          
+
           Write-Host "Full version: $fullVersion"
           Write-Host "Product version: $version"
           Write-Host "NSIS-compatible version: $nsisVersion"
-          
+
           $json = Get-Content wails.json | ConvertFrom-Json
           $json.info.productVersion = $nsisVersion
           $json | ConvertTo-Json -Depth 10 | Set-Content wails.json
-          
+
           Write-Host "Updated wails.json:"
           Get-Content wails.json
 
@@ -234,7 +234,7 @@ jobs:
         run: |
           Write-Host "Starting Wails build with NSIS..."
           wails build -platform windows/amd64 -nsis -ldflags="-X main.Version=${{ steps.version.outputs.VERSION }}" -v 2
-          
+
           Write-Host "`nBuild completed. Checking output..."
           if (Test-Path "build/bin") {
             Get-ChildItem -Path build/bin -Recurse | Format-Table Name, Length, LastWriteTime
@@ -247,7 +247,7 @@ jobs:
         shell: pwsh
         run: |
           cd build/bin
-          
+
           # Check for portable executable
           if (Test-Path "${{ env.APP_NAME }}.exe") {
             Rename-Item "${{ env.APP_NAME }}.exe" "${{ env.APP_NAME }}-windows-amd64.exe"
@@ -256,7 +256,7 @@ jobs:
             Write-Error "Portable executable not found!"
             exit 1
           }
-          
+
           # Check for NSIS installer
           if (Test-Path "${{ env.APP_NAME }}-amd64-installer.exe") {
             Rename-Item "${{ env.APP_NAME }}-amd64-installer.exe" "${{ env.APP_NAME }}-windows-amd64-installer.exe"
@@ -312,7 +312,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+          cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 
       - name: Install Wails
@@ -421,7 +421,7 @@ jobs:
           else
             CHANGELOG=$(git log --pretty=format:"- %s (%h)" | head -50)
           fi
-          
+
           # Use heredoc for multiline output
           {
             echo "CHANGELOG<<EOF"
@@ -439,7 +439,7 @@ jobs:
             ${{ steps.changelog.outputs.CHANGELOG }}
 
             ## Downloads
-            
+
             | Platform | Architecture | File | Description |
             |----------|-------------|------|-------------|
             | **Windows** | x64 | `${{ env.APP_NAME }}-windows-amd64-installer.exe` | Recommended installer |
@@ -447,37 +447,37 @@ jobs:
             | **macOS** | Universal (Intel + Apple Silicon) | `${{ env.APP_NAME }}-macos-universal.dmg` | Disk image |
             | **Linux** | x64 | `${{ env.APP_NAME }}-linux-amd64.AppImage` | AppImage (recommended) |
             | **Linux** | x64 | `${{ env.APP_NAME }}-linux-amd64.tar.gz` | Tarball |
-            
+
             ## Installation Notes
-            
+
             ### Windows
             - Download and run the installer, or use the portable `.exe` directly
             - You may see a SmartScreen warning - click "More info" → "Run anyway"
             - Deep links (`ybdownloader://`) are registered automatically by the installer
-            
+
             ### macOS
             - Open the `.dmg` file and drag the app to Applications
             - First launch: Right-click → Open (to bypass Gatekeeper)
             - Deep links (`ybdownloader://`) are registered automatically
-            
+
             ### Linux
             **AppImage (Recommended):**
             - Download the `.AppImage` file
             - Make it executable: `chmod +x ${{ env.APP_NAME }}-linux-amd64.AppImage`
             - Run it directly - no installation needed
             - For desktop integration (including deep links), use [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher)
-            
+
             **Tarball:**
             - Extract: `tar -xzf ${{ env.APP_NAME }}-linux-amd64.tar.gz`
             - Run `./install-protocol.sh ./ybdownloader-linux-amd64` to register deep links
             - Requires GTK3 and WebKit2GTK 4.1
-            
+
             ### FFmpeg
             FFmpeg is required for audio conversion. The app will prompt you to download it automatically if not found.
-            
+
             ### Browser Extension
             Install the YBDownloader browser extension to add videos directly from YouTube with one click!
-            
+
           files: |
             dist/*
           draft: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,9 @@ run:
 
 linters:
   default: none
+  exclusions:
+    paths:
+    - frontend/node_modules
   enable:
   - errcheck
   - govet

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   timeout: 5m
-  go: "1.25"
+  go: "1.26"
   tests: false
 
 linters:

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # YBDownloader
 
 ### 🚨 Legal Notice 🚨
+
 This software is provided as a technical demonstration and is intended for use only with content that you own or have explicit rights to download, such as CC0 or Creative Commons–licensed media.
 The author does not encourage, support, or condone the use of this software in violation of applicable laws or third-party terms of service.
 
-
-[![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![Go](https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![CI](https://github.com/teofanis/ybdownloader/actions/workflows/ci.yml/badge.svg)](https://github.com/teofanis/ybdownloader/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/teofanis/ybdownloader/graph/badge.svg?token=FDFRYKFUVW)](https://codecov.io/gh/teofanis/ybdownloader)
 [![CodeQL](https://github.com/teofanis/ybdownloader/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/teofanis/ybdownloader/actions/workflows/github-code-scanning/codeql)
 ![GH Downloads](https://img.shields.io/github/downloads/teofanis/ybdownloader/total)
 [![Latest Release](https://img.shields.io/github/v/release/teofanis/ybdownloader)](https://github.com/teofanis/ybdownloader/releases)
-
 
 A desktop YouTube downloader built with [Wails](https://wails.io/) (Go + React).
 
@@ -41,22 +40,23 @@ When I discovered Wails, I wanted to see what a native Go backend with a React f
 
 ## Tech Stack
 
-| Layer | Tech |
-|-------|------|
-| Backend | Go 1.25, [yt-dlp](https://github.com/yt-dlp/yt-dlp) (default), [kkdai/youtube](https://github.com/kkdai/youtube) (legacy) |
-| Frontend | React 19, TypeScript, Tailwind CSS, Zustand |
-| Framework | [Wails v2](https://wails.io/) |
-| UI Components | [shadcn/ui](https://ui.shadcn.com/) |
+| Layer         | Tech                                                                                                                      |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Backend       | Go 1.26, [yt-dlp](https://github.com/yt-dlp/yt-dlp) (default), [kkdai/youtube](https://github.com/kkdai/youtube) (legacy) |
+| Frontend      | React 19, TypeScript, Tailwind CSS, Zustand                                                                               |
+| Framework     | [Wails v2](https://wails.io/)                                                                                             |
+| UI Components | [shadcn/ui](https://ui.shadcn.com/)                                                                                       |
 
 ## Getting Started
 
 ### Prerequisites
 
-- Go 1.25+
+- Go 1.26+
 - Node.js 20+
 - Wails CLI: `go install github.com/wailsapp/wails/v2/cmd/wails@latest`
 
 **Linux only:**
+
 ```bash
 # Ubuntu/Debian
 sudo apt-get install libgtk-3-dev libwebkit2gtk-4.1-dev
@@ -106,10 +106,12 @@ cd frontend && npm run test:coverage
 ### Linting
 
 Pre-commit hooks are set up via Husky. On commit, it runs:
+
 - `gofmt` + `go vet` + `golangci-lint` for Go files
 - `prettier` + `eslint` for TypeScript/React files
 
 You can also run manually:
+
 ```bash
 npm run lint        # lint everything
 npm run lint:go     # just Go
@@ -156,7 +158,7 @@ PRs welcome if you want to tackle any of these.
 If you find this useful:
 
 - ⭐ Star the repo
-- ☕ [Buy me a coffee](https://buymeacoffee.com/teofanis) 
+- ☕ [Buy me a coffee](https://buymeacoffee.com/teofanis)
 - 💰 [PayPal](https://www.paypal.com/paypalme/teofanis)
 - 💖 [Thanks.dev](https://thanks.dev/u/gh/teofanis)
 - 💜 [Sponsor on GitHub](https://github.com/sponsors/teofanis)
@@ -175,4 +177,4 @@ MIT - do whatever you want with it.
 
 ---
 
-*This started as a playground project and still is one. If something breaks, open an issue!*
+_This started as a playground project and still is one. If something breaks, open an issue!_

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -178,6 +178,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -560,6 +561,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -582,6 +584,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1288,6 +1291,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3004,8 +3008,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3075,6 +3078,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3085,6 +3089,7 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3094,6 +3099,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3131,6 +3137,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.0.tgz",
       "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.0",
         "@typescript-eslint/types": "8.50.0",
@@ -3498,6 +3505,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3568,7 +3576,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3768,6 +3775,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4172,8 +4180,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4344,6 +4351,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5021,6 +5029,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -5259,6 +5268,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5286,6 +5296,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -5542,7 +5553,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5988,6 +5998,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6139,6 +6150,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6240,7 +6252,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6302,6 +6313,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6311,6 +6323,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6349,8 +6362,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -6893,6 +6905,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7015,6 +7028,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7131,6 +7145,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7295,6 +7310,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -7387,6 +7403,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7399,6 +7416,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.16.tgz",
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,14 @@
 module ybdownloader
 
-go 1.25.0
+go 1.26.3
 
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/kkdai/youtube/v2 v2.10.5
-	github.com/wailsapp/wails/v2 v2.12.0
+	github.com/wailsapp/wails/v2 v2.11.0
 )
 
 require (
-	git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/bitly/go-simplejson v0.5.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3 h1:N3IGoHHp9pb6mj1cbXbuaSXV/UMKwmbKLf53nQmtqMA=
-git.sr.ht/~jackmordaunt/go-toast/v2 v2.0.3/go.mod h1:QtOLZGz8olr4qH2vWK0QH0w0O4T9fEIjMuWpKUsH7nc=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
@@ -76,8 +74,8 @@ github.com/wailsapp/go-webview2 v1.0.22 h1:YT61F5lj+GGaat5OB96Aa3b4QA+mybD0Ggq6N
 github.com/wailsapp/go-webview2 v1.0.22/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
 github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhwHs=
 github.com/wailsapp/mimetype v1.4.1/go.mod h1:9aV5k31bBOv5z6u+QP8TltzvNGJPmNJD4XlAL3U+j3o=
-github.com/wailsapp/wails/v2 v2.12.0 h1:BHO/kLNWFHYjCzucxbzAYZWUjub1Tvb4cSguQozHn5c=
-github.com/wailsapp/wails/v2 v2.12.0/go.mod h1:mo1bzK1DEJrobt7YrBjgxvb5Sihb1mhAY09hppbibQg=
+github.com/wailsapp/wails/v2 v2.11.0 h1:seLacV8pqupq32IjS4Y7V8ucab0WZwtK6VvUVxSBtqQ=
+github.com/wailsapp/wails/v2 v2.11.0/go.mod h1:jrf0ZaM6+GBc1wRmXsM8cIvzlg0karYin3erahI4+0k=
 golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
 golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
 golang.org/x/net v0.0.0-20210505024714-0287a6fb4125/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/internal/infra/converter/converter.go
+++ b/internal/infra/converter/converter.go
@@ -241,6 +241,7 @@ func (s *Service) StartConversionWithTrim(id, inputPath, outputPath, presetID st
 
 func (s *Service) runConversion(job *core.ConversionJob, ffmpegArgs []string) {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	s.mu.Lock()
 	s.cancelFuncs[job.ID] = cancel


### PR DESCRIPTION
- Updated Go version in .golangci.yml, go.mod, and CI workflows to 1.26.
- Downgraded Wails dependency from v2.12.0 to v2.11.0 in go.mod and go.sum.
- Updated README to reflect the new Go version.
- Minor formatting adjustments in CI and release workflows.
