### PR TITLE
fix: refresh set download path for enqueued items and minor setting adjustments

### DIFF
--- a/frontend/src/features/settings/SettingsTab.test.tsx
+++ b/frontend/src/features/settings/SettingsTab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, waitFor, act } from "@testing-library/react";
+import { screen, waitFor, act, fireEvent } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { BACKEND_YTDLP } from "@/types";
 
@@ -227,5 +227,76 @@ describe("SettingsTab - Settings Loading Behavior", () => {
 
     // Should still only have been called once
     expect(api.getSettings).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SettingsTab - Save and Reset", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStore = createMockStore();
+    mockI18nLanguage = "en";
+  });
+
+  it("enables save button after editing a field", async () => {
+    renderWithProviders(<SettingsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText("settings.title")).toBeInTheDocument();
+    });
+
+    const saveButton = screen.getByRole("button", { name: /settings.save/i });
+    expect(saveButton).toBeDisabled();
+
+    const inputs = screen.getAllByRole("textbox");
+    if (inputs.length > 0) {
+      fireEvent.change(inputs[0], { target: { value: "/new/path" } });
+    }
+
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled();
+    });
+  });
+
+  it("calls saveSettings on save click", async () => {
+    renderWithProviders(<SettingsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText("settings.title")).toBeInTheDocument();
+    });
+
+    const inputs = screen.getAllByRole("textbox");
+    if (inputs.length > 0) {
+      fireEvent.change(inputs[0], { target: { value: "/new/path" } });
+    }
+
+    const saveButton = screen.getByRole("button", { name: /settings.save/i });
+    await waitFor(() => {
+      expect(saveButton).not.toBeDisabled();
+    });
+
+    await act(async () => {
+      fireEvent.click(saveButton);
+    });
+
+    await waitFor(() => {
+      expect(api.saveSettings).toHaveBeenCalled();
+    });
+  });
+
+  it("calls resetSettings on reset click", async () => {
+    renderWithProviders(<SettingsTab />);
+
+    await waitFor(() => {
+      expect(screen.getByText("settings.title")).toBeInTheDocument();
+    });
+
+    const resetButton = screen.getByRole("button", { name: /settings.reset/i });
+    await act(async () => {
+      fireEvent.click(resetButton);
+    });
+
+    await waitFor(() => {
+      expect(api.resetSettings).toHaveBeenCalled();
+    });
   });
 });

--- a/frontend/src/features/settings/SettingsTab.test.tsx
+++ b/frontend/src/features/settings/SettingsTab.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, waitFor, act } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
+import { BACKEND_YTDLP } from "@/types";
 
 // Mock settings for tests
 const mockSettings = {
@@ -10,7 +11,7 @@ const mockSettings = {
   defaultAudioQuality: "192",
   defaultVideoQuality: "720p",
   maxConcurrentDownloads: 2,
-  downloadBackend: "yt-dlp" as const,
+  downloadBackend: BACKEND_YTDLP,
   language: "en",
   themeMode: "system",
   accentColor: "purple",
@@ -101,7 +102,7 @@ vi.mock("@/lib/api", () => ({
       mp3: ["-x", "--audio-format", "mp3"],
     })
   ),
-  getDownloadBackend: vi.fn(() => Promise.resolve("yt-dlp")),
+  getDownloadBackend: vi.fn(() => Promise.resolve(BACKEND_YTDLP)),
   openLogs: vi.fn(() => Promise.resolve()),
 }));
 

--- a/frontend/src/features/settings/SettingsTab.tsx
+++ b/frontend/src/features/settings/SettingsTab.tsx
@@ -7,6 +7,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useAppStore } from "@/store";
 import { useTheme } from "@/components/theme-provider";
 import * as api from "@/lib/api";
+import { BACKEND_YTDLP } from "@/types";
 import type { Settings } from "@/types";
 import type { ThemeMode } from "@/lib/themes";
 import {
@@ -165,7 +166,9 @@ export function SettingsTab() {
       <FormatSettings settings={local} onUpdate={update} />
       <ConcurrentDownloadsSettings settings={local} onUpdate={update} />
       <DownloadEngineSettings settings={local} onUpdate={update} />
-      <YtDlpSettings settings={local} onUpdate={update} />
+      {local.downloadBackend === BACKEND_YTDLP && (
+        <YtDlpSettings settings={local} onUpdate={update} />
+      )}
       <FFmpegSettings settings={local} onUpdate={update} />
       <LogSettings logLevel={local.logLevel || "info"} onChange={update} />
     </div>

--- a/frontend/src/features/settings/components/DownloadEngineSettings.test.tsx
+++ b/frontend/src/features/settings/components/DownloadEngineSettings.test.tsx
@@ -91,4 +91,21 @@ describe("DownloadEngineSettings", () => {
     expect(builtinRadio).toBeChecked();
     expect(ytdlpRadio).not.toBeChecked();
   });
+
+  it("calls onUpdate when yt-dlp is selected from builtin", () => {
+    const builtinSettings: Settings = {
+      ...mockSettings,
+      downloadBackend: BACKEND_BUILTIN,
+    };
+
+    renderWithProviders(
+      <DownloadEngineSettings settings={builtinSettings} onUpdate={onUpdate} />
+    );
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: "settings.engine.ytdlp" })
+    );
+
+    expect(onUpdate).toHaveBeenCalledWith("downloadBackend", BACKEND_YTDLP);
+  });
 });

--- a/frontend/src/features/settings/components/DownloadEngineSettings.test.tsx
+++ b/frontend/src/features/settings/components/DownloadEngineSettings.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, fireEvent } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { DownloadEngineSettings } from "./DownloadEngineSettings";
+import { BACKEND_YTDLP, BACKEND_BUILTIN } from "@/types";
 import type { Settings } from "@/types";
 
 vi.mock("react-i18next", () => ({
@@ -18,7 +19,7 @@ const mockSettings: Settings = {
   defaultAudioQuality: "192",
   defaultVideoQuality: "720p",
   maxConcurrentDownloads: 2,
-  downloadBackend: "yt-dlp",
+  downloadBackend: BACKEND_YTDLP,
 };
 
 describe("DownloadEngineSettings", () => {
@@ -34,8 +35,12 @@ describe("DownloadEngineSettings", () => {
     );
 
     expect(screen.getByText("settings.engine.title")).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "settings.engine.ytdlp" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: "settings.engine.builtin" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: "settings.engine.ytdlp" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: "settings.engine.builtin" })
+    ).toBeInTheDocument();
   });
 
   it("yt-dlp option is selected by default when settings.downloadBackend is yt-dlp", () => {
@@ -43,8 +48,12 @@ describe("DownloadEngineSettings", () => {
       <DownloadEngineSettings settings={mockSettings} onUpdate={onUpdate} />
     );
 
-    const ytdlpRadio = screen.getByRole("radio", { name: "settings.engine.ytdlp" });
-    const builtinRadio = screen.getByRole("radio", { name: "settings.engine.builtin" });
+    const ytdlpRadio = screen.getByRole("radio", {
+      name: "settings.engine.ytdlp",
+    });
+    const builtinRadio = screen.getByRole("radio", {
+      name: "settings.engine.builtin",
+    });
 
     expect(ytdlpRadio).toBeChecked();
     expect(builtinRadio).not.toBeChecked();
@@ -55,23 +64,29 @@ describe("DownloadEngineSettings", () => {
       <DownloadEngineSettings settings={mockSettings} onUpdate={onUpdate} />
     );
 
-    fireEvent.click(screen.getByRole("radio", { name: "settings.engine.builtin" }));
+    fireEvent.click(
+      screen.getByRole("radio", { name: "settings.engine.builtin" })
+    );
 
-    expect(onUpdate).toHaveBeenCalledWith("downloadBackend", "builtin");
+    expect(onUpdate).toHaveBeenCalledWith("downloadBackend", BACKEND_BUILTIN);
   });
 
   it("builtin is selected when settings say builtin", () => {
     const builtinSettings: Settings = {
       ...mockSettings,
-      downloadBackend: "builtin",
+      downloadBackend: BACKEND_BUILTIN,
     };
 
     renderWithProviders(
       <DownloadEngineSettings settings={builtinSettings} onUpdate={onUpdate} />
     );
 
-    const ytdlpRadio = screen.getByRole("radio", { name: "settings.engine.ytdlp" });
-    const builtinRadio = screen.getByRole("radio", { name: "settings.engine.builtin" });
+    const ytdlpRadio = screen.getByRole("radio", {
+      name: "settings.engine.ytdlp",
+    });
+    const builtinRadio = screen.getByRole("radio", {
+      name: "settings.engine.builtin",
+    });
 
     expect(builtinRadio).toBeChecked();
     expect(ytdlpRadio).not.toBeChecked();

--- a/frontend/src/features/settings/components/DownloadEngineSettings.tsx
+++ b/frontend/src/features/settings/components/DownloadEngineSettings.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { BACKEND_YTDLP, BACKEND_BUILTIN } from "@/types";
 import type { Settings, DownloadBackend } from "@/types";
 import { SettingsCard } from "./SettingsCard";
 
@@ -21,14 +22,21 @@ export function DownloadEngineSettings({
       description={t("settings.engine.description")}
     >
       <RadioGroup
-        value={settings.downloadBackend || "yt-dlp"}
+        value={settings.downloadBackend || BACKEND_YTDLP}
         onValueChange={(v) => onUpdate("downloadBackend", v as DownloadBackend)}
         className="space-y-3"
       >
         <div className="flex items-start space-x-3 rounded-md border p-3">
-          <RadioGroupItem value="yt-dlp" id="backend-ytdlp" className="mt-1" />
+          <RadioGroupItem
+            value={BACKEND_YTDLP}
+            id="backend-ytdlp"
+            className="mt-1"
+          />
           <div className="space-y-1">
-            <Label htmlFor="backend-ytdlp" className="cursor-pointer font-medium">
+            <Label
+              htmlFor="backend-ytdlp"
+              className="cursor-pointer font-medium"
+            >
               {t("settings.engine.ytdlp")}
             </Label>
             <p className="text-xs text-muted-foreground">
@@ -39,12 +47,15 @@ export function DownloadEngineSettings({
 
         <div className="flex items-start space-x-3 rounded-md border p-3">
           <RadioGroupItem
-            value="builtin"
+            value={BACKEND_BUILTIN}
             id="backend-builtin"
             className="mt-1"
           />
           <div className="space-y-1">
-            <Label htmlFor="backend-builtin" className="cursor-pointer font-medium">
+            <Label
+              htmlFor="backend-builtin"
+              className="cursor-pointer font-medium"
+            >
               {t("settings.engine.builtin")}
             </Label>
             <p className="text-xs text-muted-foreground">

--- a/frontend/src/features/settings/components/DownloadSettings.test.tsx
+++ b/frontend/src/features/settings/components/DownloadSettings.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithProviders } from "@/test/test-utils";
+import {
+  SavePathSettings,
+  FormatSettings,
+  ConcurrentDownloadsSettings,
+} from "./DownloadSettings";
+import { BACKEND_YTDLP } from "@/types";
+import type { Settings } from "@/types";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en", changeLanguage: vi.fn() },
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  selectDirectory: vi.fn(),
+}));
+
+const mockSettings: Settings = {
+  version: 2,
+  defaultSavePath: "/downloads",
+  defaultFormat: "mp3",
+  defaultAudioQuality: "192",
+  defaultVideoQuality: "720p",
+  maxConcurrentDownloads: 2,
+  downloadBackend: BACKEND_YTDLP,
+};
+
+describe("SavePathSettings", () => {
+  const onUpdate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders save path input with current value", () => {
+    renderWithProviders(
+      <SavePathSettings settings={mockSettings} onUpdate={onUpdate} />
+    );
+
+    const input = screen.getByDisplayValue("/downloads");
+    expect(input).toBeInTheDocument();
+  });
+
+  it("calls onUpdate when path input changes", () => {
+    renderWithProviders(
+      <SavePathSettings settings={mockSettings} onUpdate={onUpdate} />
+    );
+
+    const input = screen.getByDisplayValue("/downloads");
+    fireEvent.change(input, { target: { value: "/new/path" } });
+
+    expect(onUpdate).toHaveBeenCalledWith("defaultSavePath", "/new/path");
+  });
+
+  it("renders browse button", () => {
+    renderWithProviders(
+      <SavePathSettings settings={mockSettings} onUpdate={onUpdate} />
+    );
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+});
+
+describe("FormatSettings", () => {
+  const onUpdate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders format settings card", () => {
+    renderWithProviders(
+      <FormatSettings settings={mockSettings} onUpdate={onUpdate} />
+    );
+
+    expect(
+      screen.getAllByText("settings.fields.format").length
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("ConcurrentDownloadsSettings", () => {
+  const onUpdate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders concurrent downloads settings", () => {
+    renderWithProviders(
+      <ConcurrentDownloadsSettings
+        settings={mockSettings}
+        onUpdate={onUpdate}
+      />
+    );
+
+    expect(
+      screen.getAllByText("settings.fields.concurrentDownloads").length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/features/settings/components/YtDlpSettings.test.tsx
+++ b/frontend/src/features/settings/components/YtDlpSettings.test.tsx
@@ -3,6 +3,7 @@ import { screen, waitFor, fireEvent } from "@testing-library/react";
 import { renderWithProviders } from "@/test/test-utils";
 import { YtDlpSettings } from "./YtDlpSettings";
 import * as api from "@/lib/api";
+import { BACKEND_YTDLP } from "@/types";
 import type { Settings } from "@/types";
 
 vi.mock("react-i18next", () => ({
@@ -45,7 +46,7 @@ const mockSettings: Settings = {
   defaultAudioQuality: "192",
   defaultVideoQuality: "720p",
   maxConcurrentDownloads: 2,
-  downloadBackend: "yt-dlp",
+  downloadBackend: BACKEND_YTDLP,
 };
 
 describe("YtDlpSettings", () => {
@@ -97,7 +98,9 @@ describe("YtDlpSettings", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /settings\.ytdlp\.download/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /settings\.ytdlp\.download/i })
+      ).toBeInTheDocument();
     });
   });
 
@@ -110,7 +113,9 @@ describe("YtDlpSettings", () => {
       expect(screen.getByText("settings.ytdlp.title")).toBeInTheDocument();
     });
 
-    const customPathInput = screen.getByPlaceholderText("settings.ytdlp.customPathPlaceholder");
+    const customPathInput = screen.getByPlaceholderText(
+      "settings.ytdlp.customPathPlaceholder"
+    );
     expect(customPathInput).toBeInTheDocument();
   });
 
@@ -123,7 +128,9 @@ describe("YtDlpSettings", () => {
       expect(screen.getByText("settings.ytdlp.title")).toBeInTheDocument();
     });
 
-    const customPathInput = screen.getByPlaceholderText("settings.ytdlp.customPathPlaceholder");
+    const customPathInput = screen.getByPlaceholderText(
+      "settings.ytdlp.customPathPlaceholder"
+    );
     fireEvent.change(customPathInput, { target: { value: "/custom/yt-dlp" } });
 
     expect(onUpdate).toHaveBeenCalledWith("ytDlpPath", "/custom/yt-dlp");
@@ -144,7 +151,9 @@ describe("YtDlpSettings", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/settings\.ytdlp\.jsRuntime/)).toBeInTheDocument();
+      expect(
+        screen.getByText(/settings\.ytdlp\.jsRuntime/)
+      ).toBeInTheDocument();
       expect(screen.getByText("node (/usr/bin/node)")).toBeInTheDocument();
     });
   });
@@ -163,7 +172,9 @@ describe("YtDlpSettings", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("settings.ytdlp.noJsRuntime")).toBeInTheDocument();
+      expect(
+        screen.getByText("settings.ytdlp.noJsRuntime")
+      ).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/features/settings/components/YtDlpSettings.test.tsx
+++ b/frontend/src/features/settings/components/YtDlpSettings.test.tsx
@@ -190,4 +190,54 @@ describe("YtDlpSettings", () => {
       expect(screen.getByText("2026.03.03")).toBeInTheDocument();
     });
   });
+
+  it("calls onUpdate with parsed flags when extra flags change", async () => {
+    renderWithProviders(
+      <YtDlpSettings settings={mockSettings} onUpdate={onUpdate} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("settings.ytdlp.title")).toBeInTheDocument();
+    });
+
+    const advancedButton = screen.getByText("settings.ytdlp.advancedFlags");
+    fireEvent.click(advancedButton);
+
+    const textarea = screen.getByPlaceholderText(
+      "settings.ytdlp.extraFlagsPlaceholder"
+    );
+    fireEvent.change(textarea, {
+      target: { value: "--proxy http://example.com" },
+    });
+
+    expect(onUpdate).toHaveBeenCalledWith("ytDlpExtraFlags", [
+      "--proxy",
+      "http://example.com",
+    ]);
+  });
+
+  it("calls onUpdate with undefined when extra flags cleared", async () => {
+    const settingsWithFlags = {
+      ...mockSettings,
+      ytDlpExtraFlags: ["--proxy", "http://example.com"],
+    };
+
+    renderWithProviders(
+      <YtDlpSettings settings={settingsWithFlags} onUpdate={onUpdate} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("settings.ytdlp.title")).toBeInTheDocument();
+    });
+
+    const advancedButton = screen.getByText("settings.ytdlp.advancedFlags");
+    fireEvent.click(advancedButton);
+
+    const textarea = screen.getByPlaceholderText(
+      "settings.ytdlp.extraFlagsPlaceholder"
+    );
+    fireEvent.change(textarea, { target: { value: "" } });
+
+    expect(onUpdate).toHaveBeenCalledWith("ytDlpExtraFlags", undefined);
+  });
 });

--- a/frontend/src/features/settings/components/YtDlpSettings.tsx
+++ b/frontend/src/features/settings/components/YtDlpSettings.tsx
@@ -22,6 +22,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import * as api from "@/lib/api";
 import type { YtDlpStatus } from "@/lib/api";
+import { BACKEND_YTDLP } from "@/types";
 import type { Settings } from "@/types";
 import { EventsOn } from "../../../../wailsjs/runtime/runtime";
 import { SettingsCard, Field } from "./SettingsCard";
@@ -80,13 +81,11 @@ export function YtDlpSettings({ settings, onUpdate }: YtDlpSettingsProps) {
   const extraFlagsStr = (settings.ytDlpExtraFlags || []).join(" ");
 
   const handleExtraFlagsChange = (value: string) => {
-    const flags = value
-      .split(/\s+/)
-      .filter((f) => f.length > 0);
+    const flags = value.split(/\s+/).filter((f) => f.length > 0);
     onUpdate("ytDlpExtraFlags", flags.length > 0 ? flags : undefined);
   };
 
-  const isActive = settings.downloadBackend === "yt-dlp";
+  const isActive = settings.downloadBackend === BACKEND_YTDLP;
 
   return (
     <SettingsCard
@@ -196,9 +195,7 @@ export function YtDlpSettings({ settings, onUpdate }: YtDlpSettingsProps) {
         >
           <Input
             value={settings.ytDlpPath || ""}
-            onChange={(e) =>
-              onUpdate("ytDlpPath", e.target.value || undefined)
-            }
+            onChange={(e) => onUpdate("ytDlpPath", e.target.value || undefined)}
             placeholder={t("settings.ytdlp.customPathPlaceholder")}
           />
         </Field>
@@ -209,7 +206,7 @@ export function YtDlpSettings({ settings, onUpdate }: YtDlpSettingsProps) {
           <CollapsibleTrigger asChild>
             <Button
               variant="ghost"
-              className="flex w-full items-center justify-between p-0 text-sm font-medium"
+              className="flex w-full items-center justify-between p-0 px-3 text-sm font-medium"
             >
               {t("settings.ytdlp.advancedFlags")}
               <span className="text-xs text-muted-foreground">
@@ -244,7 +241,9 @@ export function YtDlpSettings({ settings, onUpdate }: YtDlpSettingsProps) {
             >
               <Textarea
                 value={extraFlagsStr}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => handleExtraFlagsChange(e.target.value)}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  handleExtraFlagsChange(e.target.value)
+                }
                 placeholder={t("settings.ytdlp.extraFlagsPlaceholder")}
                 className="min-h-[60px] font-mono text-xs"
               />

--- a/frontend/src/store/index.test.ts
+++ b/frontend/src/store/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { useAppStore } from "./index";
+import { BACKEND_YTDLP } from "@/types";
 import type {
   QueueItemWithProgress,
   DownloadProgress,
@@ -151,7 +152,7 @@ describe("useAppStore", () => {
       defaultAudioQuality: "192",
       defaultVideoQuality: "720p",
       maxConcurrentDownloads: 2,
-      downloadBackend: "yt-dlp",
+      downloadBackend: BACKEND_YTDLP,
     };
 
     it("defaults to null", () => {

--- a/frontend/src/store/index.test.ts
+++ b/frontend/src/store/index.test.ts
@@ -21,6 +21,9 @@ describe("useAppStore", () => {
       selectedFormat: "mp3",
       isAddingToQueue: false,
       error: null,
+      browseSearchQuery: "",
+      browseResults: [],
+      browseActiveTab: "search",
     });
   });
 
@@ -228,6 +231,50 @@ describe("useAppStore", () => {
       expect(useAppStore.getState().isAddingToQueue).toBe(false);
       useAppStore.getState().setAddingToQueue(true);
       expect(useAppStore.getState().isAddingToQueue).toBe(true);
+    });
+  });
+
+  describe("browse state", () => {
+    it("can set browse search query", () => {
+      useAppStore.getState().setBrowseSearchQuery("test query");
+      expect(useAppStore.getState().browseSearchQuery).toBe("test query");
+    });
+
+    it("can set browse active tab", () => {
+      useAppStore.getState().setBrowseActiveTab("trending");
+      expect(useAppStore.getState().browseActiveTab).toBe("trending");
+    });
+  });
+
+  describe("progress edge cases", () => {
+    it("updateProgress with unknown itemId leaves queue unchanged", () => {
+      const mockItem: QueueItemWithProgress = {
+        id: "test-1",
+        url: "https://youtube.com/watch?v=test",
+        state: "queued",
+        format: "mp3",
+        savePath: "/downloads",
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      };
+
+      useAppStore.getState().setQueue([mockItem]);
+
+      const progress: DownloadProgress = {
+        itemId: "unknown-id",
+        state: "downloading",
+        percent: 50,
+        downloadedBytes: 5000000,
+        totalBytes: 10000000,
+        speed: 1000000,
+        eta: 5,
+      };
+
+      useAppStore.getState().updateProgress(progress);
+
+      expect(useAppStore.getState().queue).toHaveLength(1);
+      expect(useAppStore.getState().queue[0].state).toBe("queued");
+      expect(useAppStore.getState().queue[0].progress).toBeUndefined();
     });
   });
 });

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -53,7 +53,10 @@ export interface QueueItemWithProgress extends QueueItem {
   progress?: DownloadProgress;
 }
 
-export type DownloadBackend = "builtin" | "yt-dlp";
+export const BACKEND_YTDLP = "yt-dlp" as const;
+export const BACKEND_BUILTIN = "builtin" as const;
+
+export type DownloadBackend = typeof BACKEND_YTDLP | typeof BACKEND_BUILTIN;
 
 export interface Settings {
   version: number;

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1913,6 +1913,40 @@ func TestGetYtDlpStatus_notAvailable(t *testing.T) {
 	_ = status
 }
 
+func TestHandleDeepLink_DownloadSuccess(t *testing.T) {
+	qm := newMockQueueManager()
+	store := &mockSettingsStore{
+		settings: &core.Settings{
+			DefaultSavePath: "/downloads",
+			DefaultFormat:   core.FormatMP3,
+			DownloadBackend: core.BackendYtDlp,
+		},
+	}
+
+	app := &App{
+		ctx:           context.Background(),
+		queueManager:  qm,
+		settingsStore: store,
+	}
+
+	// handleDeepLink → handleDeepLinkAdd calls runtime.EventsEmit which
+	// requires a real Wails context. Test the same flow via AddToQueue which
+	// is the core of what handleDeepLinkAdd does after parsing the deep link.
+	item, err := app.AddToQueue("https://www.youtube.com/watch?v=dQw4w9WgXcQ", "mp3")
+	if err != nil {
+		t.Fatalf("AddToQueue() error = %v", err)
+	}
+	if item == nil {
+		t.Fatal("AddToQueue() returned nil item")
+	}
+	if item.Format != core.FormatMP3 {
+		t.Errorf("item.Format = %v, want %v", item.Format, core.FormatMP3)
+	}
+	if len(qm.items) != 1 {
+		t.Errorf("expected 1 item in queue, got %d", len(qm.items))
+	}
+}
+
 func TestYtDlpStatus_struct(t *testing.T) {
 	status := YtDlpStatus{
 		Available:    true,

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -89,6 +89,28 @@ func (m *mockFileSystem) SanitizeFilename(name string) string {
 	return name
 }
 
+// Mock Downloader for testing
+type mockDownloader struct {
+	fetchError    error
+	downloadError error
+}
+
+func (m *mockDownloader) FetchMetadata(_ context.Context, _ string) (*core.VideoMetadata, error) {
+	if m.fetchError != nil {
+		return nil, m.fetchError
+	}
+	return &core.VideoMetadata{
+		ID:       "dQw4w9WgXcQ",
+		Title:    "Test Video",
+		Author:   "Test Author",
+		Duration: 213,
+	}, nil
+}
+
+func (m *mockDownloader) Download(_ context.Context, _ *core.QueueItem, _ func(core.DownloadProgress)) error {
+	return m.downloadError
+}
+
 // Mock QueueManager for testing
 type mockQueueManager struct {
 	items      map[string]*core.QueueItem
@@ -1913,6 +1935,218 @@ func TestGetYtDlpStatus_notAvailable(t *testing.T) {
 	_ = status
 }
 
+func TestApp_ImportURLs_Success(t *testing.T) {
+	qm := newMockQueueManager()
+	store := &mockSettingsStore{}
+	app := &App{
+		settingsStore: store,
+		queueManager:  qm,
+	}
+
+	result := app.ImportURLs([]string{
+		"https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		"https://youtu.be/abc12345678",
+	}, "mp3")
+
+	if result.Added != 2 {
+		t.Errorf("Added = %d, want 2", result.Added)
+	}
+	if result.Invalid != 0 {
+		t.Errorf("Invalid = %d, want 0", result.Invalid)
+	}
+	if result.Skipped != 0 {
+		t.Errorf("Skipped = %d, want 0", result.Skipped)
+	}
+}
+
+func TestApp_ImportURLs_MixedValidity(t *testing.T) {
+	qm := newMockQueueManager()
+	store := &mockSettingsStore{}
+	app := &App{
+		settingsStore: store,
+		queueManager:  qm,
+	}
+
+	result := app.ImportURLs([]string{
+		"https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		"not-a-youtube-url",
+		"",
+		"   ",
+		"https://youtu.be/abc12345678",
+	}, "mp3")
+
+	if result.Added != 2 {
+		t.Errorf("Added = %d, want 2", result.Added)
+	}
+	if result.Invalid != 1 {
+		t.Errorf("Invalid = %d, want 1", result.Invalid)
+	}
+}
+
+func TestApp_ImportURLs_BatchDedup(t *testing.T) {
+	qm := newMockQueueManager()
+	store := &mockSettingsStore{}
+	app := &App{
+		settingsStore: store,
+		queueManager:  qm,
+	}
+
+	result := app.ImportURLs([]string{
+		"https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		"https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		"https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+	}, "mp3")
+
+	if result.Added != 1 {
+		t.Errorf("Added = %d, want 1", result.Added)
+	}
+	if result.Skipped != 2 {
+		t.Errorf("Skipped = %d, want 2", result.Skipped)
+	}
+}
+
+func TestApp_ImportURLs_AlreadyInQueue(t *testing.T) {
+	qm := newMockQueueManager()
+	store := &mockSettingsStore{}
+	app := &App{
+		settingsStore: store,
+		queueManager:  qm,
+	}
+
+	qm.items["existing"] = core.NewQueueItem("existing", "https://www.youtube.com/watch?v=dQw4w9WgXcQ", core.FormatMP3, "/tmp")
+
+	result := app.ImportURLs([]string{
+		"https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+		"https://youtu.be/abc12345678",
+	}, "mp3")
+
+	if result.Added != 1 {
+		t.Errorf("Added = %d, want 1", result.Added)
+	}
+	if result.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1", result.Skipped)
+	}
+}
+
+func TestApp_ImportURLs_SettingsError(t *testing.T) {
+	qm := newMockQueueManager()
+	store := &mockSettingsStore{loadError: errors.New("settings error")}
+	app := &App{
+		settingsStore: store,
+		queueManager:  qm,
+	}
+
+	result := app.ImportURLs([]string{
+		"https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+	}, "mp3")
+
+	if len(result.Errors) == 0 {
+		t.Error("expected errors for settings failure")
+	}
+	if result.Added != 0 {
+		t.Errorf("Added = %d, want 0", result.Added)
+	}
+}
+
+func TestApp_ImportURLs_AddItemError(t *testing.T) {
+	qm := newMockQueueManager()
+	qm.addError = errors.New("queue full")
+	store := &mockSettingsStore{}
+	app := &App{
+		settingsStore: store,
+		queueManager:  qm,
+	}
+
+	result := app.ImportURLs([]string{
+		"https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+	}, "mp3")
+
+	if result.Added != 0 {
+		t.Errorf("Added = %d, want 0", result.Added)
+	}
+	if result.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1 (error → skipped)", result.Skipped)
+	}
+}
+
+func TestApp_GetYtDlpStatus_NotAvailable(t *testing.T) {
+	mgr := downloader.NewYtDlpManager(&mockFileSystem{}, func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	})
+	app := &App{
+		fs:           &mockFileSystem{},
+		ytdlpManager: mgr,
+	}
+
+	status := app.GetYtDlpStatus()
+	if status.Available {
+		t.Error("Expected Available=false when yt-dlp not installed")
+	}
+	if status.Path != "" {
+		t.Errorf("Expected empty Path, got %q", status.Path)
+	}
+}
+
+func TestApp_SearchYouTube_DefaultLimit(t *testing.T) {
+	yt := newMockYouTubeSearcher()
+	app := &App{
+		ctx:             context.Background(),
+		youtubeSearcher: yt,
+	}
+
+	result, err := app.SearchYouTube("test", 0)
+	if err != nil {
+		t.Fatalf("SearchYouTube() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("SearchYouTube() returned nil")
+	}
+}
+
+func TestApp_GetTrendingVideos_DefaultLimit(t *testing.T) {
+	yt := newMockYouTubeSearcher()
+	app := &App{
+		ctx:             context.Background(),
+		youtubeSearcher: yt,
+	}
+
+	result, err := app.GetTrendingVideos("US", -1)
+	if err != nil {
+		t.Fatalf("GetTrendingVideos() error = %v", err)
+	}
+	if result == nil {
+		t.Fatal("GetTrendingVideos() returned nil")
+	}
+}
+
+func TestApp_CheckForUpdate_Error(t *testing.T) {
+	upd := newMockAppUpdater()
+	upd.checkError = errors.New("network error")
+	app := &App{
+		ctx:        context.Background(),
+		appUpdater: upd,
+	}
+
+	_, err := app.CheckForUpdate()
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestApp_DownloadUpdate_Error(t *testing.T) {
+	upd := newMockAppUpdater()
+	upd.downloadError = errors.New("download failed")
+	app := &App{
+		ctx:        context.Background(),
+		appUpdater: upd,
+	}
+
+	_, err := app.DownloadUpdate()
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
 func TestHandleDeepLink_DownloadSuccess(t *testing.T) {
 	qm := newMockQueueManager()
 	store := &mockSettingsStore{
@@ -1944,6 +2178,69 @@ func TestHandleDeepLink_DownloadSuccess(t *testing.T) {
 	}
 	if len(qm.items) != 1 {
 		t.Errorf("expected 1 item in queue, got %d", len(qm.items))
+	}
+}
+
+func TestApp_SaveSettings_Error(t *testing.T) {
+	store := &mockSettingsStore{saveError: errors.New("write error")}
+	app := &App{settingsStore: store}
+
+	err := app.SaveSettings(core.DefaultSettings("/tmp"))
+	if err == nil {
+		t.Error("SaveSettings() expected error")
+	}
+}
+
+func TestApp_SaveSettings_LogLevelChange(t *testing.T) {
+	store := &mockSettingsStore{
+		settings: &core.Settings{LogLevel: "info"},
+	}
+	app := &App{settingsStore: store}
+
+	s := core.DefaultSettings("/tmp")
+	s.LogLevel = "debug"
+	err := app.SaveSettings(s)
+	if err != nil {
+		t.Fatalf("SaveSettings() error = %v", err)
+	}
+	if store.settings.LogLevel != "debug" {
+		t.Errorf("LogLevel = %q, want debug", store.settings.LogLevel)
+	}
+}
+
+func TestApp_ResetSettings_LoadError(t *testing.T) {
+	store := &mockSettingsStore{}
+	app := &App{settingsStore: store}
+
+	// First reset succeeds, but override Load to fail after reset
+	store.loadError = errors.New("load failed after reset")
+	_, err := app.ResetSettings()
+	if err == nil {
+		t.Error("ResetSettings() expected error when load fails after reset")
+	}
+}
+
+func TestApp_FetchMetadata_WithDownloader(t *testing.T) {
+	store := &mockSettingsStore{}
+	qm := newMockQueueManager()
+	dl := &mockDownloader{}
+
+	app := &App{
+		ctx:           context.Background(),
+		settingsStore: store,
+		queueManager:  qm,
+		downloader:    dl,
+	}
+
+	meta, err := app.FetchMetadata("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+	if err != nil {
+		t.Fatalf("FetchMetadata() error = %v", err)
+	}
+	if meta == nil {
+		t.Fatal("FetchMetadata() returned nil")
+	}
+	if meta.Title != "Test Video" {
+		t.Errorf("Title = %q, want %q", meta.Title, "Test Video")
 	}
 }
 

--- a/internal/core/settings_test.go
+++ b/internal/core/settings_test.go
@@ -98,3 +98,29 @@ func TestSettingsVersion_Constant(t *testing.T) {
 		t.Errorf("SettingsVersion = %d, should be at least 1", SettingsVersion)
 	}
 }
+
+func TestSettings_Validate_DownloadBackend(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    DownloadBackend
+		expected DownloadBackend
+	}{
+		{"valid builtin stays", BackendBuiltin, BackendBuiltin},
+		{"valid yt-dlp stays", BackendYtDlp, BackendYtDlp},
+		{"invalid normalizes to yt-dlp", DownloadBackend("invalid"), BackendYtDlp},
+		{"empty normalizes to yt-dlp", DownloadBackend(""), BackendYtDlp},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Settings{
+				DownloadBackend:        tt.input,
+				MaxConcurrentDownloads: 2,
+			}
+			_ = s.Validate()
+			if s.DownloadBackend != tt.expected {
+				t.Errorf("DownloadBackend = %q, want %q", s.DownloadBackend, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/infra/converter/converter_test.go
+++ b/internal/infra/converter/converter_test.go
@@ -1081,14 +1081,22 @@ func TestStartConversion_WithCustomArgs_CreatesJob(t *testing.T) {
 		t.Fatalf("StartConversion() error = %v", err)
 	}
 
+	// Only read fields set before the goroutine starts (ID, OutputPath, InputPath).
+	// Reading job.State is racy because runConversion modifies it concurrently.
 	if job.ID != "custom-job" {
 		t.Errorf("job.ID = %q, want %q", job.ID, "custom-job")
 	}
-	if job.State != core.ConversionQueued {
-		t.Errorf("job.State = %v, want %v", job.State, core.ConversionQueued)
-	}
 	if job.OutputPath != outputPath {
 		t.Errorf("job.OutputPath = %q, want %q", job.OutputPath, outputPath)
+	}
+
+	// Use GetJob to read State safely under the mutex.
+	stored, err := service.GetJob("custom-job")
+	if err != nil {
+		t.Fatalf("GetJob() error = %v", err)
+	}
+	if stored.InputPath != inputPath {
+		t.Errorf("stored.InputPath = %q, want %q", stored.InputPath, inputPath)
 	}
 }
 

--- a/internal/infra/converter/converter_test.go
+++ b/internal/infra/converter/converter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"ybdownloader/internal/core"
@@ -74,7 +75,7 @@ func TestGetPresetsByCategory(t *testing.T) {
 
 	// Test non-existent category
 	emptyPresets := service.GetPresetsByCategory("nonexistent")
-	if emptyPresets != nil && len(emptyPresets) > 0 {
+	if len(emptyPresets) > 0 {
 		t.Error("GetPresetsByCategory('nonexistent') should return empty slice")
 	}
 }
@@ -187,6 +188,19 @@ func TestStartConversion_NoPresetOrArgs(t *testing.T) {
 	_, err := service.StartConversion("job1", "/input.mp3", "/output.mp4", "", nil)
 	if err == nil {
 		t.Error("StartConversion() expected error when no preset or args provided")
+	}
+}
+
+func TestNew_NonexistentPath(t *testing.T) {
+	service := New("/nonexistent/ffmpeg", nil)
+	if service == nil {
+		t.Fatal("New() returned nil")
+	}
+	if service.ffmpegPath != "/nonexistent/ffmpeg" {
+		t.Errorf("ffmpegPath = %q, want %q", service.ffmpegPath, "/nonexistent/ffmpeg")
+	}
+	if service.ffprobePath != "" {
+		t.Logf("ffprobePath resolved to %q (likely from system PATH)", service.ffprobePath)
 	}
 }
 
@@ -819,5 +833,372 @@ func TestConversionJob_States(t *testing.T) {
 		if job.State != state {
 			t.Errorf("State not set correctly: %v", state)
 		}
+	}
+}
+
+func TestNew_FFprobeDetection_NoFFmpegPath(t *testing.T) {
+	service := New("", nil)
+	if service.ffprobePath != "" {
+		t.Errorf("ffprobePath = %q, want empty when ffmpegPath is empty", service.ffprobePath)
+	}
+}
+
+func TestNew_FFprobeDetection_FFmpegExists(t *testing.T) {
+	service := New("/usr/bin/ffmpeg", nil)
+	// ffprobePath is set based on runtime availability; verify it's a string (not panic)
+	_ = service.ffprobePath
+}
+
+func TestNew_FFprobeDetection_NextToFFmpeg(t *testing.T) {
+	if _, err := os.Stat("/usr/bin/ffmpeg"); os.IsNotExist(err) {
+		t.Skip("ffmpeg not available")
+	}
+	if _, err := os.Stat("/usr/bin/ffprobe"); os.IsNotExist(err) {
+		t.Skip("ffprobe not at /usr/bin/ffprobe")
+	}
+
+	service := New("/usr/bin/ffmpeg", nil)
+	if service.ffprobePath == "" {
+		t.Error("ffprobePath should be detected next to ffmpeg")
+	}
+	if service.ffprobePath != "/usr/bin/ffprobe" {
+		t.Errorf("ffprobePath = %q, want /usr/bin/ffprobe", service.ffprobePath)
+	}
+}
+
+func TestNew_FFprobeDetection_NonexistentDir(t *testing.T) {
+	service := New("/nonexistent/path/ffmpeg", nil)
+	// ffprobe won't be found next to a nonexistent ffmpeg, but may be found via LookPath
+	// The key assertion is: no panic
+	_ = service.ffprobePath
+}
+
+func TestNew_NilEmit(t *testing.T) {
+	service := New("/usr/bin/ffmpeg", nil)
+	if service.emit != nil {
+		t.Error("emit should be nil when passed nil")
+	}
+}
+
+func TestNew_PresetsInitialized(t *testing.T) {
+	service := New("", nil)
+	if service.presets == nil {
+		t.Error("presets should not be nil")
+	}
+	if len(service.presets) == 0 {
+		t.Error("presets should contain default presets")
+	}
+}
+
+func TestNew_MapsInitialized(t *testing.T) {
+	service := New("", nil)
+	if service.jobs == nil {
+		t.Error("jobs map should be initialized")
+	}
+	if service.cancelFuncs == nil {
+		t.Error("cancelFuncs map should be initialized")
+	}
+}
+
+func TestAnalyzeFile_NoFFprobe_ErrorMessage(t *testing.T) {
+	service := New("", nil)
+
+	_, err := service.AnalyzeFile(context.Background(), "/some/file.mp3")
+	if err == nil {
+		t.Fatal("AnalyzeFile() expected error when ffprobe not available")
+	}
+	if err.Error() != "ffprobe not available" {
+		t.Errorf("AnalyzeFile() error = %q, want %q", err.Error(), "ffprobe not available")
+	}
+}
+
+func TestGenerateWaveform_NoFFmpeg_ErrorMessage(t *testing.T) {
+	service := New("", nil)
+
+	_, err := service.GenerateWaveform(context.Background(), "/some/file.mp3", 100)
+	if err == nil {
+		t.Fatal("GenerateWaveform() expected error when ffmpeg not available")
+	}
+	if err.Error() != "ffmpeg not available" {
+		t.Errorf("GenerateWaveform() error = %q, want %q", err.Error(), "ffmpeg not available")
+	}
+}
+
+func TestGenerateWaveform_NegativeSamples(t *testing.T) {
+	if _, err := os.Stat("/usr/bin/ffmpeg"); os.IsNotExist(err) {
+		t.Skip("ffmpeg not available")
+	}
+
+	service := New("/usr/bin/ffmpeg", nil)
+	tempDir := t.TempDir()
+	testFile := filepath.Join(tempDir, "test.mp3")
+	if err := os.WriteFile(testFile, []byte("not real audio"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Negative samples should default to 200 without panic
+	_, _ = service.GenerateWaveform(context.Background(), testFile, -5)
+}
+
+func TestGenerateWaveform_ContextCancelled(t *testing.T) {
+	if _, err := os.Stat("/usr/bin/ffmpeg"); os.IsNotExist(err) {
+		t.Skip("ffmpeg not available")
+	}
+
+	service := New("/usr/bin/ffmpeg", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := service.GenerateWaveform(ctx, "/some/file.mp3", 100)
+	if err == nil {
+		t.Error("GenerateWaveform() should fail with cancelled context")
+	}
+}
+
+func TestGenerateThumbnails_NoFFmpeg_ErrorMessage(t *testing.T) {
+	service := New("", nil)
+
+	_, err := service.GenerateThumbnails(context.Background(), "/some/file.mp4", 10, "/tmp")
+	if err == nil {
+		t.Fatal("GenerateThumbnails() expected error when ffmpeg not available")
+	}
+	if err.Error() != "ffmpeg not available" {
+		t.Errorf("GenerateThumbnails() error = %q, want %q", err.Error(), "ffmpeg not available")
+	}
+}
+
+func TestStartConversion_EmptyFFmpegPath_ErrorMessage(t *testing.T) {
+	service := New("", nil)
+
+	_, err := service.StartConversion("job1", "/input.mp3", "/output.mp4", "preset-id", nil)
+	if err == nil {
+		t.Fatal("StartConversion() expected error when ffmpeg not available")
+	}
+	if err.Error() != "ffmpeg not available" {
+		t.Errorf("StartConversion() error = %q, want %q", err.Error(), "ffmpeg not available")
+	}
+}
+
+func TestStartConversionWithTrim_EmptyFFmpegPath(t *testing.T) {
+	service := New("", nil)
+
+	trim := &core.TrimOptions{StartTime: 5.0, EndTime: 15.0}
+	_, err := service.StartConversionWithTrim("job1", "/input.mp4", "/output.mp4", "preset-id", nil, trim)
+	if err == nil {
+		t.Fatal("StartConversionWithTrim() expected error when ffmpeg not available")
+	}
+	if err.Error() != "ffmpeg not available" {
+		t.Errorf("error = %q, want %q", err.Error(), "ffmpeg not available")
+	}
+}
+
+func TestStartConversionWithTrim_NoPresetNoArgs(t *testing.T) {
+	service := New("/usr/bin/ffmpeg", nil)
+
+	_, err := service.StartConversionWithTrim("job1", "/input.mp4", "/output.mp4", "", nil, nil)
+	if err == nil {
+		t.Fatal("StartConversionWithTrim() expected error with no preset or args")
+	}
+	if err.Error() != "either presetId or customArgs required" {
+		t.Errorf("error = %q, want %q", err.Error(), "either presetId or customArgs required")
+	}
+}
+
+func TestStartConversionWithTrim_InvalidPreset(t *testing.T) {
+	service := New("/usr/bin/ffmpeg", nil)
+
+	_, err := service.StartConversionWithTrim("job1", "/input.mp4", "", "nonexistent-preset", nil, nil)
+	if err == nil {
+		t.Fatal("StartConversionWithTrim() expected error for invalid preset")
+	}
+}
+
+func TestStartConversionWithTrim_OutputPathGenerated_Converted(t *testing.T) {
+	service := New("/usr/bin/ffmpeg", nil)
+
+	presets := service.GetPresets()
+	if len(presets) == 0 {
+		t.Skip("No presets available")
+	}
+
+	tempDir := t.TempDir()
+	inputPath := filepath.Join(tempDir, "input.mp4")
+	if err := os.WriteFile(inputPath, []byte("fake"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	job, err := service.StartConversionWithTrim("gen-path-job", inputPath, "", presets[0].ID, nil, nil)
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	if job.OutputPath == "" {
+		t.Error("OutputPath should be auto-generated")
+	}
+	if !strings.Contains(job.OutputPath, "_converted") {
+		t.Errorf("OutputPath %q should contain '_converted' when no trim", job.OutputPath)
+	}
+}
+
+func TestStartConversionWithTrim_OutputPathGenerated_Trimmed(t *testing.T) {
+	service := New("/usr/bin/ffmpeg", nil)
+
+	presets := service.GetPresets()
+	if len(presets) == 0 {
+		t.Skip("No presets available")
+	}
+
+	tempDir := t.TempDir()
+	inputPath := filepath.Join(tempDir, "input.mp4")
+	if err := os.WriteFile(inputPath, []byte("fake"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	trim := &core.TrimOptions{StartTime: 5.0, EndTime: 25.0}
+	job, err := service.StartConversionWithTrim("trim-path-job", inputPath, "", presets[0].ID, nil, trim)
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	if !strings.Contains(job.OutputPath, "_trimmed") {
+		t.Errorf("OutputPath %q should contain '_trimmed' when trimming", job.OutputPath)
+	}
+}
+
+func TestStartConversion_WithCustomArgs_CreatesJob(t *testing.T) {
+	service := New("/usr/bin/ffmpeg", nil)
+
+	tempDir := t.TempDir()
+	inputPath := filepath.Join(tempDir, "input.mp4")
+	if err := os.WriteFile(inputPath, []byte("fake"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	outputPath := filepath.Join(tempDir, "output.mp3")
+
+	job, err := service.StartConversion("custom-job", inputPath, outputPath, "", []string{"-vn", "-acodec", "libmp3lame"})
+	if err != nil {
+		t.Fatalf("StartConversion() error = %v", err)
+	}
+
+	if job.ID != "custom-job" {
+		t.Errorf("job.ID = %q, want %q", job.ID, "custom-job")
+	}
+	if job.State != core.ConversionQueued {
+		t.Errorf("job.State = %v, want %v", job.State, core.ConversionQueued)
+	}
+	if job.OutputPath != outputPath {
+		t.Errorf("job.OutputPath = %q, want %q", job.OutputPath, outputPath)
+	}
+}
+
+func TestFormatDuration_EdgeCases(t *testing.T) {
+	tests := []struct {
+		seconds  float64
+		expected string
+	}{
+		{0.001, "00:00:00.001"},
+		{0.5, "00:00:00.500"},
+		{3599.999, "00:59:59.999"},
+		{86400, "24:00:00.000"},
+	}
+
+	for _, tt := range tests {
+		result := formatDuration(tt.seconds)
+		if result != tt.expected {
+			t.Errorf("formatDuration(%f) = %q, want %q", tt.seconds, result, tt.expected)
+		}
+	}
+}
+
+func TestParseFrameRate_EdgeCases(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected float64
+	}{
+		{"1/1", 1.0},
+		{"120/1", 120.0},
+		{"a/b/c", 0.0},
+		{"/1", 0.0},
+		{"30/", 0.0},
+	}
+
+	for _, tt := range tests {
+		result := parseFrameRate(tt.input)
+		if tt.expected == 0 && result != 0 {
+			t.Errorf("parseFrameRate(%q) = %v, want 0", tt.input, result)
+		}
+		if tt.expected != 0 && result != tt.expected {
+			t.Errorf("parseFrameRate(%q) = %v, want %v", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestUpdateJobState_ProgressField(t *testing.T) {
+	service := New("/usr/bin/ffmpeg", nil)
+	service.jobs["j1"] = &core.ConversionJob{
+		ID:    "j1",
+		State: core.ConversionQueued,
+	}
+
+	service.updateJobState("j1", core.ConversionConverting, 42.5, "")
+
+	job := service.jobs["j1"]
+	if job.Progress != 42.5 {
+		t.Errorf("Progress = %v, want 42.5", job.Progress)
+	}
+}
+
+func TestUpdateJobState_ErrorNotOverwrittenWhenEmpty(t *testing.T) {
+	service := New("/usr/bin/ffmpeg", nil)
+	service.jobs["j1"] = &core.ConversionJob{
+		ID:    "j1",
+		State: core.ConversionConverting,
+		Error: "previous error",
+	}
+
+	service.updateJobState("j1", core.ConversionCompleted, 100, "")
+
+	job := service.jobs["j1"]
+	if job.Error != "previous error" {
+		t.Errorf("Error = %q, want preserved 'previous error' when empty errMsg", job.Error)
+	}
+}
+
+func TestGetAllJobs_ReturnsAll(t *testing.T) {
+	service := New("/usr/bin/ffmpeg", nil)
+	service.jobs["a"] = &core.ConversionJob{ID: "a"}
+	service.jobs["b"] = &core.ConversionJob{ID: "b"}
+	service.jobs["c"] = &core.ConversionJob{ID: "c"}
+
+	jobs := service.GetAllJobs()
+	if len(jobs) != 3 {
+		t.Errorf("GetAllJobs() returned %d jobs, want 3", len(jobs))
+	}
+}
+
+func TestClearCompletedJobs_Empty(t *testing.T) {
+	service := New("/usr/bin/ffmpeg", nil)
+
+	// Should not panic on empty map
+	service.ClearCompletedJobs()
+
+	if len(service.jobs) != 0 {
+		t.Errorf("jobs should still be empty, got %d", len(service.jobs))
+	}
+}
+
+func TestStartConversion_DelegatesTo_StartConversionWithTrim(t *testing.T) {
+	service := New("", nil)
+
+	// Both should fail with the same error since ffmpeg is empty
+	_, err1 := service.StartConversion("j1", "/in", "/out", "preset", nil)
+	_, err2 := service.StartConversionWithTrim("j2", "/in", "/out", "preset", nil, nil)
+
+	if err1 == nil || err2 == nil {
+		t.Fatal("expected errors from both")
+	}
+	if err1.Error() != err2.Error() {
+		t.Errorf("StartConversion and StartConversionWithTrim should produce same error: %q vs %q", err1.Error(), err2.Error())
 	}
 }

--- a/internal/infra/downloader/downloader_test.go
+++ b/internal/infra/downloader/downloader_test.go
@@ -79,7 +79,9 @@ func TestGetDownloadExtension(t *testing.T) {
 	}{
 		{"video/mp4", "mp4"},
 		{"video/webm", "webm"},
+		{"audio/mp4", "mp4"}, // "mp4" substring matches first case
 		{"audio/webm", "webm"},
+		{"audio/m4a", "m4a"},                // "m4a" without "mp4" hits the m4a case
 		{"application/octet-stream", "mp4"}, // default
 		{"", "mp4"},                         // default
 	}
@@ -387,6 +389,37 @@ func TestCopyFile_LargeFile(t *testing.T) {
 	}
 	if info.Size() != int64(len(content)) {
 		t.Errorf("dest file size = %d, want %d", info.Size(), len(content))
+	}
+}
+
+func TestDownloadWithProgress_ReportsSpeed(t *testing.T) {
+	fs := newTestFS()
+	getSettings := func() (*core.Settings, error) {
+		return core.DefaultSettings("/tmp"), nil
+	}
+	d, _ := New(fs, getSettings)
+
+	data := bytes.Repeat([]byte("x"), 1024*64) // 64KB
+	reader := &slowReader{data: data}
+	var writer bytes.Buffer
+
+	var lastProgress core.DownloadProgress
+	onProgress := func(p core.DownloadProgress) {
+		lastProgress = p
+	}
+
+	ctx := context.Background()
+	err := d.downloadWithProgress(ctx, reader, &writer, int64(len(data)), "speed-test", onProgress)
+	if err != nil {
+		t.Fatalf("downloadWithProgress() error = %v", err)
+	}
+
+	// The final progress report should have 100%
+	if lastProgress.Percent != 100 {
+		t.Errorf("last progress percent = %v, want 100", lastProgress.Percent)
+	}
+	if lastProgress.ItemID != "speed-test" {
+		t.Errorf("last progress itemID = %q, want 'speed-test'", lastProgress.ItemID)
 	}
 }
 

--- a/internal/infra/downloader/ffmpeg_manager_test.go
+++ b/internal/infra/downloader/ffmpeg_manager_test.go
@@ -101,11 +101,140 @@ func TestGetPlatformKey(t *testing.T) {
 			if key != "linux-arm64" {
 				t.Errorf("Linux arm64 platform key = %q, want %q", key, "linux-arm64")
 			}
+		case "arm":
+			if key != "linux-armhf" {
+				t.Errorf("Linux arm platform key = %q, want %q", key, "linux-armhf")
+			}
+		case "386":
+			if key != "linux-32" {
+				t.Errorf("Linux 386 platform key = %q, want %q", key, "linux-32")
+			}
 		}
 	case "darwin":
 		if key != "osx-64" {
 			t.Errorf("macOS platform key = %q, want %q", key, "osx-64")
 		}
+	}
+}
+
+func TestGetPlatformKey_NotEmpty(t *testing.T) {
+	key := getPlatformKey()
+	supported := map[string]bool{
+		"windows": true,
+		"linux":   true,
+		"darwin":  true,
+	}
+	if supported[runtime.GOOS] && key == "" {
+		t.Errorf("getPlatformKey() returned empty for supported OS %q/%q", runtime.GOOS, runtime.GOARCH)
+	}
+}
+
+func TestFindFFmpeg_AlwaysReturnsNonEmpty_WhenInstalled(t *testing.T) {
+	path, err := findFFmpeg()
+	if err != nil {
+		t.Skipf("ffmpeg not installed, skipping: %v", err)
+	}
+	if path == "" {
+		t.Error("findFFmpeg() returned empty path without error")
+	}
+}
+
+func TestFindFFmpeg_ErrorMessage(t *testing.T) {
+	if IsFFmpegInstalled() {
+		t.Skip("ffmpeg is installed, cannot test error path")
+	}
+	_, err := findFFmpeg()
+	if err == nil {
+		t.Error("findFFmpeg() should return error when ffmpeg is not installed")
+	}
+	if !strContains(err.Error(), "ffmpeg not found") {
+		t.Errorf("findFFmpeg() error = %q, want message containing 'ffmpeg not found'", err.Error())
+	}
+}
+
+func TestFFmpegManager_GetFFprobePath_UserConfigured(t *testing.T) {
+	fs := newMockFileSystem()
+	customProbePath := "/custom/ffprobe"
+	fs.setFileExists(customProbePath, true)
+
+	settings := &core.Settings{FFprobePath: customProbePath}
+	manager := NewFFmpegManager(fs, func() (*core.Settings, error) {
+		return settings, nil
+	}, func(*core.Settings) error { return nil })
+
+	path, err := manager.GetFFprobePath()
+	if err != nil {
+		t.Fatalf("GetFFprobePath() error = %v", err)
+	}
+	if path != customProbePath {
+		t.Errorf("GetFFprobePath() = %q, want %q", path, customProbePath)
+	}
+}
+
+func TestFFmpegManager_GetFFprobePath_SettingsError(t *testing.T) {
+	fs := newMockFileSystem()
+	manager := NewFFmpegManager(fs, func() (*core.Settings, error) {
+		return nil, fmt.Errorf("settings unavailable")
+	}, func(*core.Settings) error { return nil })
+
+	_, err := manager.GetFFprobePath()
+	if err == nil {
+		t.Error("GetFFprobePath() expected error when settings fail")
+	}
+}
+
+func TestFFmpegManager_GetFFmpegPath_SettingsError(t *testing.T) {
+	fs := newMockFileSystem()
+	manager := NewFFmpegManager(fs, func() (*core.Settings, error) {
+		return nil, fmt.Errorf("settings unavailable")
+	}, func(*core.Settings) error { return nil })
+
+	_, err := manager.GetFFmpegPath()
+	if err == nil {
+		t.Error("GetFFmpegPath() expected error when settings fail")
+	}
+}
+
+func TestFFmpegManager_GetCompanionBinaryPath(t *testing.T) {
+	fs := newMockFileSystem()
+	manager := NewFFmpegManager(fs, func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	}, func(*core.Settings) error { return nil })
+
+	got := manager.getCompanionBinaryPath("/usr/local/bin/ffmpeg", "ffprobe")
+	wantDir := filepath.Dir("/usr/local/bin/ffmpeg")
+	expectedName := "ffprobe"
+	if runtime.GOOS == "windows" {
+		expectedName = "ffprobe.exe"
+	}
+	want := filepath.Join(wantDir, expectedName)
+	if got != want {
+		t.Errorf("getCompanionBinaryPath() = %q, want %q", got, want)
+	}
+}
+
+func TestFFmpegManager_ExtractZipBinary_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	zipPath := filepath.Join(tmpDir, "test.zip")
+	destDir := filepath.Join(tmpDir, "extracted")
+
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		t.Fatalf("Failed to create dest dir: %v", err)
+	}
+
+	createTestZipAtRoot(t, zipPath, "something_else")
+
+	fs := newMockFileSystem()
+	manager := NewFFmpegManager(fs, func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	}, func(*core.Settings) error { return nil })
+
+	err := manager.extractZipBinary(zipPath, destDir, "ffmpeg")
+	if err == nil {
+		t.Error("extractZipBinary() expected error when binary not in archive")
+	}
+	if !strContains(err.Error(), "not found in archive") {
+		t.Errorf("extractZipBinary() error = %q, want message containing 'not found in archive'", err.Error())
 	}
 }
 
@@ -346,10 +475,6 @@ func TestFFmpegManager_FetchBinaryURLs(t *testing.T) {
 }
 
 func TestFFmpegManager_DownloadFile_Success(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping network test in short mode")
-	}
-
 	// Create a test server that returns mock data
 	content := []byte("mock ffmpeg binary content")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -397,10 +522,6 @@ func TestFFmpegManager_DownloadFile_Success(t *testing.T) {
 }
 
 func TestFFmpegManager_DownloadFile_Cancel(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping network test in short mode")
-	}
-
 	// Create a slow server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Length", "10000000")

--- a/internal/infra/downloader/ytdlp_manager_test.go
+++ b/internal/infra/downloader/ytdlp_manager_test.go
@@ -20,18 +20,28 @@ func TestGetYtDlpDownloadURL(t *testing.T) {
 	if url == "" {
 		t.Error("getYtDlpDownloadURL() returned empty URL")
 	}
-	switch runtime.GOOS {
-	case "linux":
-		if runtime.GOARCH == "amd64" && !strings.Contains(url, "yt-dlp_linux") {
-			t.Errorf("got %q, want URL containing yt-dlp_linux", url)
-		}
-	case "darwin":
-		if !strings.Contains(url, "yt-dlp_macos") {
-			t.Errorf("got %q, want URL containing yt-dlp_macos", url)
-		}
-	case "windows":
-		if !strings.Contains(url, "yt-dlp.exe") {
-			t.Errorf("got %q, want URL containing yt-dlp.exe", url)
+	if !strings.HasPrefix(url, ytDlpReleasesBaseURL+"/") {
+		t.Errorf("URL %q does not start with expected base %q", url, ytDlpReleasesBaseURL)
+	}
+
+	tests := []struct {
+		os   string
+		arch string
+		want string
+	}{
+		{"linux", "amd64", "yt-dlp_linux"},
+		{"linux", "arm64", "yt-dlp_linux_aarch64"},
+		{"darwin", "amd64", "yt-dlp_macos"},
+		{"darwin", "arm64", "yt-dlp_macos"},
+		{"windows", "amd64", "yt-dlp.exe"},
+		{"windows", "arm64", "yt-dlp_arm64.exe"},
+	}
+
+	for _, tt := range tests {
+		if tt.os == runtime.GOOS && tt.arch == runtime.GOARCH {
+			if !strings.Contains(url, tt.want) {
+				t.Errorf("on %s/%s: got %q, want URL containing %q", tt.os, tt.arch, url, tt.want)
+			}
 		}
 	}
 }
@@ -49,6 +59,48 @@ func TestGetDenoDownloadURL(t *testing.T) {
 	}
 	if !strings.Contains(url, ".zip") {
 		t.Errorf("got %q, want URL containing .zip", url)
+	}
+
+	tests := []struct {
+		os   string
+		arch string
+		want string
+	}{
+		{"linux", "amd64", "deno-x86_64-unknown-linux-gnu.zip"},
+		{"linux", "arm64", "deno-aarch64-unknown-linux-gnu.zip"},
+		{"darwin", "amd64", "deno-x86_64-apple-darwin.zip"},
+		{"darwin", "arm64", "deno-aarch64-apple-darwin.zip"},
+		{"windows", "amd64", "deno-x86_64-pc-windows-msvc.zip"},
+	}
+
+	for _, tt := range tests {
+		if tt.os == runtime.GOOS && tt.arch == runtime.GOARCH {
+			if !strings.HasSuffix(url, tt.want) {
+				t.Errorf("on %s/%s: got %q, want URL ending with %q", tt.os, tt.arch, url, tt.want)
+			}
+		}
+	}
+}
+
+func TestGetDenoDownloadURL_ContainsPlatformIdentifier(t *testing.T) {
+	url, err := getDenoDownloadURL()
+	if err != nil {
+		t.Fatalf("getDenoDownloadURL() error = %v", err)
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		if !strings.Contains(url, "linux") {
+			t.Errorf("on linux, URL %q should contain 'linux'", url)
+		}
+	case "darwin":
+		if !strings.Contains(url, "apple-darwin") {
+			t.Errorf("on darwin, URL %q should contain 'apple-darwin'", url)
+		}
+	case "windows":
+		if !strings.Contains(url, "windows") {
+			t.Errorf("on windows, URL %q should contain 'windows'", url)
+		}
 	}
 }
 
@@ -273,5 +325,83 @@ func TestEnsureYtDlp_alreadyAvailable(t *testing.T) {
 	err := mgr.EnsureYtDlp(context.Background(), func(float64, string) {})
 	if err != nil {
 		t.Errorf("EnsureYtDlp() = %v, want nil when already available", err)
+	}
+}
+
+func TestYtDlpManager_GetBundledBinaryPath(t *testing.T) {
+	fs := newTestFS()
+	mgr := NewYtDlpManager(fs, func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	})
+
+	path := mgr.getBundledBinaryPath()
+	expectedDir := filepath.Join(fs.configDir, "bin")
+	expectedName := "yt-dlp"
+	if runtime.GOOS == "windows" {
+		expectedName = "yt-dlp.exe"
+	}
+	want := filepath.Join(expectedDir, expectedName)
+	if path != want {
+		t.Errorf("getBundledBinaryPath() = %q, want %q", path, want)
+	}
+}
+
+func TestYtDlpManager_GetBundledDir(t *testing.T) {
+	fs := newTestFS()
+	mgr := NewYtDlpManager(fs, func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	})
+
+	dir := mgr.getBundledDir()
+	want := filepath.Join(fs.configDir, "bin")
+	if dir != want {
+		t.Errorf("getBundledDir() = %q, want %q", dir, want)
+	}
+}
+
+func TestYtDlpManager_GetJSRuntimePath_BundledDeno(t *testing.T) {
+	fs := newTestFS()
+	bundledDeno := filepath.Join(fs.configDir, "bin", "deno"+binaryExt())
+	fs.fileExists[bundledDeno] = true
+
+	mgr := NewYtDlpManager(fs, func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	})
+
+	name, path := mgr.GetJSRuntimePath()
+	if name != "deno" {
+		t.Errorf("GetJSRuntimePath() name = %q, want 'deno'", name)
+	}
+	if path != bundledDeno {
+		t.Errorf("GetJSRuntimePath() path = %q, want %q", path, bundledDeno)
+	}
+}
+
+func TestYtDlpManager_HasJSRuntime_WithBundledDeno(t *testing.T) {
+	fs := newTestFS()
+	bundledDeno := filepath.Join(fs.configDir, "bin", "deno"+binaryExt())
+	fs.fileExists[bundledDeno] = true
+
+	mgr := NewYtDlpManager(fs, func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	})
+
+	if !mgr.HasJSRuntime() {
+		t.Error("HasJSRuntime() should return true when bundled deno exists")
+	}
+}
+
+func TestYtDlpManager_EnsureJSRuntime_AlreadyAvailable(t *testing.T) {
+	fs := newTestFS()
+	bundledDeno := filepath.Join(fs.configDir, "bin", "deno"+binaryExt())
+	fs.fileExists[bundledDeno] = true
+
+	mgr := NewYtDlpManager(fs, func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	})
+
+	err := mgr.EnsureJSRuntime(context.Background())
+	if err != nil {
+		t.Errorf("EnsureJSRuntime() = %v, want nil when already available", err)
 	}
 }

--- a/internal/infra/downloader/ytdlp_test.go
+++ b/internal/infra/downloader/ytdlp_test.go
@@ -476,3 +476,47 @@ func TestParseSizeString_edgeCases(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildDownloadArgs_UnknownFormat(t *testing.T) {
+	d := &YtDlpDownloader{}
+	item := &core.QueueItem{
+		ID:       "1",
+		Format:   core.Format("flac"),
+		SavePath: "/tmp",
+	}
+	settings := &core.Settings{
+		DefaultAudioQuality: core.AudioQuality192,
+		DefaultVideoQuality: core.VideoQuality720p,
+	}
+	outputTemplate := filepath.Join("/tmp", "%(title)s.%(ext)s")
+
+	args := d.buildDownloadArgs(item, settings, outputTemplate)
+
+	hasExtract := false
+	hasFormatFlag := false
+	for _, a := range args {
+		if a == "-x" {
+			hasExtract = true
+		}
+		if a == "-f" {
+			hasFormatFlag = true
+		}
+	}
+
+	if hasExtract {
+		t.Error("unknown format should not have -x flag")
+	}
+	if hasFormatFlag {
+		t.Error("unknown format should not have -f flag")
+	}
+
+	hasNewline := false
+	for _, a := range args {
+		if a == "--newline" {
+			hasNewline = true
+		}
+	}
+	if !hasNewline {
+		t.Error("unknown format should still have --newline flag")
+	}
+}

--- a/internal/infra/downloader/ytdlp_test.go
+++ b/internal/infra/downloader/ytdlp_test.go
@@ -477,6 +477,82 @@ func TestParseSizeString_edgeCases(t *testing.T) {
 	}
 }
 
+func TestNewYtDlpDownloader(t *testing.T) {
+	fs := newTestFS()
+	getSettings := func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	}
+	ytdlpMgr := NewYtDlpManager(fs, getSettings)
+	ffmpegMgr := NewFFmpegManager(fs, getSettings, func(*core.Settings) error { return nil })
+
+	d := NewYtDlpDownloader(ytdlpMgr, ffmpegMgr, fs, getSettings)
+	if d == nil {
+		t.Fatal("NewYtDlpDownloader() returned nil")
+	}
+	if d.ytdlpManager != ytdlpMgr {
+		t.Error("ytdlpManager not set correctly")
+	}
+	if d.ffmpegManager != ffmpegMgr {
+		t.Error("ffmpegManager not set correctly")
+	}
+	if d.fs != fs {
+		t.Error("fs not set correctly")
+	}
+	if d.settings == nil {
+		t.Error("settings func is nil")
+	}
+}
+
+func TestNewYtDlpDownloader_NilManagers(t *testing.T) {
+	fs := newTestFS()
+	d := NewYtDlpDownloader(nil, nil, fs, func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	})
+	if d == nil {
+		t.Fatal("NewYtDlpDownloader() returned nil even with nil managers")
+	}
+}
+
+func TestGetJSRuntime_CachesResult(t *testing.T) {
+	fs := newTestFS()
+	bundledDeno := filepath.Join(fs.configDir, "bin", "deno"+binaryExt())
+	fs.fileExists[bundledDeno] = true
+
+	ytdlpMgr := NewYtDlpManager(fs, func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	})
+	d := NewYtDlpDownloader(ytdlpMgr, nil, fs, func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	})
+
+	result1 := d.getJSRuntime()
+	result2 := d.getJSRuntime()
+	if result1 != result2 {
+		t.Errorf("getJSRuntime() not cached: first=%q, second=%q", result1, result2)
+	}
+}
+
+func TestGetJSRuntime_WithBundledDeno(t *testing.T) {
+	fs := newTestFS()
+	bundledDeno := filepath.Join(fs.configDir, "bin", "deno"+binaryExt())
+	fs.fileExists[bundledDeno] = true
+
+	ytdlpMgr := NewYtDlpManager(fs, func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	})
+	d := NewYtDlpDownloader(ytdlpMgr, nil, fs, func() (*core.Settings, error) {
+		return &core.Settings{}, nil
+	})
+
+	result := d.getJSRuntime()
+	if result == "" {
+		t.Error("getJSRuntime() should return non-empty when bundled deno exists")
+	}
+	if !strings.HasPrefix(result, "deno:") {
+		t.Errorf("getJSRuntime() = %q, expected prefix 'deno:'", result)
+	}
+}
+
 func TestBuildDownloadArgs_UnknownFormat(t *testing.T) {
 	d := &YtDlpDownloader{}
 	item := &core.QueueItem{

--- a/internal/infra/fs/filesystem_test.go
+++ b/internal/infra/fs/filesystem_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -305,5 +306,128 @@ func TestSanitizeFilename_OnlyInvalidChars(t *testing.T) {
 	result := fs.SanitizeFilename(input)
 	if result != "download" {
 		t.Errorf("SanitizeFilename(%q) = %q, want %q", input, result, "download")
+	}
+}
+
+func TestGetConfigDir_WithXDGConfigHome(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		t.Skip("XDG_CONFIG_HOME only applies on Linux")
+	}
+
+	customConfig := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", customConfig)
+
+	fs := New()
+	dir, err := fs.GetConfigDir()
+	if err != nil {
+		t.Fatalf("GetConfigDir() error = %v", err)
+	}
+
+	expected := filepath.Join(customConfig, "ybdownloader")
+	if dir != expected {
+		t.Errorf("GetConfigDir() = %q, want %q", dir, expected)
+	}
+}
+
+func TestGetConfigDir_WithoutXDGConfigHome(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		t.Skip("XDG_CONFIG_HOME only applies on Linux")
+	}
+
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	fs := New()
+	dir, err := fs.GetConfigDir()
+	if err != nil {
+		t.Fatalf("GetConfigDir() error = %v", err)
+	}
+
+	home, _ := os.UserHomeDir()
+	expected := filepath.Join(home, ".config", "ybdownloader")
+	if dir != expected {
+		t.Errorf("GetConfigDir() = %q, want %q", dir, expected)
+	}
+}
+
+func TestGetMusicDir_MusicExists(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		t.Skip("Linux-specific test")
+	}
+
+	tmpDir := t.TempDir()
+	musicDir := filepath.Join(tmpDir, "Music")
+	if err := os.MkdirAll(musicDir, 0755); err != nil {
+		t.Fatalf("failed to create Music dir: %v", err)
+	}
+	t.Setenv("HOME", tmpDir)
+
+	fs := New()
+	dir, err := fs.GetMusicDir()
+	if err != nil {
+		t.Fatalf("GetMusicDir() error = %v", err)
+	}
+
+	if dir != musicDir {
+		t.Errorf("GetMusicDir() = %q, want %q", dir, musicDir)
+	}
+}
+
+func TestGetMusicDir_FallbackToDownloads(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		t.Skip("Linux-specific test")
+	}
+
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	fs := New()
+	dir, err := fs.GetMusicDir()
+	if err != nil {
+		t.Fatalf("GetMusicDir() error = %v", err)
+	}
+
+	expected := filepath.Join(tmpDir, "Downloads")
+	if dir != expected {
+		t.Errorf("GetMusicDir() = %q, want %q", dir, expected)
+	}
+}
+
+func TestIsWritable_ReadOnlyDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root user")
+	}
+
+	tmpDir := t.TempDir()
+	readOnlyDir := filepath.Join(tmpDir, "readonly")
+	if err := os.MkdirAll(readOnlyDir, 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	if err := os.Chmod(readOnlyDir, 0555); err != nil {
+		t.Fatalf("failed to chmod dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(readOnlyDir, 0755) })
+
+	fs := New()
+	if fs.IsWritable(readOnlyDir) {
+		t.Error("IsWritable() returned true for read-only directory")
+	}
+}
+
+func TestSanitizeFilename_TruncatesLongValid(t *testing.T) {
+	fs := New()
+
+	longName := strings.Repeat("a", 250)
+	result := fs.SanitizeFilename(longName)
+	if len(result) != 200 {
+		t.Errorf("SanitizeFilename() length = %d, want 200", len(result))
+	}
+}
+
+func TestSanitizeFilename_NonPrintable(t *testing.T) {
+	fs := New()
+
+	result := fs.SanitizeFilename("hello\x01world")
+	if result != "helloworld" {
+		t.Errorf("SanitizeFilename() = %q, want %q", result, "helloworld")
 	}
 }

--- a/internal/infra/logging/logger_test.go
+++ b/internal/infra/logging/logger_test.go
@@ -1,8 +1,10 @@
 package logging
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 	"time"
 )
@@ -194,4 +196,226 @@ func TestJSONFormat(t *testing.T) {
 
 	// Log something - should not panic
 	logger.Slogger().Info("test message", "key", "value")
+}
+
+func TestCleanOldLogs_ReadDirError(t *testing.T) {
+	l := &Logger{
+		config: Config{LogDir: "/nonexistent/path", MaxAgeDays: 7},
+	}
+	l.cleanOldLogs()
+}
+
+func TestRotate_SameDayNoOp(t *testing.T) {
+	tmpDir := t.TempDir()
+	logger, err := New(Config{Level: LevelInfo, LogDir: tmpDir})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer logger.Close()
+
+	if err := logger.rotate(); err != nil {
+		t.Fatalf("second rotate() error = %v", err)
+	}
+}
+
+func TestNew_WithConsole(t *testing.T) {
+	tmpDir := t.TempDir()
+	logger, err := New(Config{Level: LevelInfo, LogDir: tmpDir, Console: true})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer logger.Close()
+
+	logger.Slogger().Info("console test")
+}
+
+func TestNew_DebugLevel(t *testing.T) {
+	tmpDir := t.TempDir()
+	logger, err := New(Config{Level: LevelDebug, LogDir: tmpDir})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer logger.Close()
+
+	logger.Slogger().Debug("debug test")
+}
+
+func TestNew_InvalidLogDir(t *testing.T) {
+	_, err := New(Config{Level: LevelInfo, LogDir: "/dev/null/impossible"})
+	if err == nil {
+		t.Fatal("New() expected error for invalid log directory")
+	}
+}
+
+func TestSetGlobalLevel_NilGlobalLogger(t *testing.T) {
+	globalMu.Lock()
+	saved := globalLogger
+	globalLogger = nil
+	globalMu.Unlock()
+	defer func() {
+		globalMu.Lock()
+		globalLogger = saved
+		globalMu.Unlock()
+	}()
+
+	SetGlobalLevel(LevelDebug)
+}
+
+func TestCheckRotate_DateChange(t *testing.T) {
+	tmpDir := t.TempDir()
+	logger, err := New(Config{Level: LevelInfo, LogDir: tmpDir})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer logger.Close()
+
+	logger.mu.Lock()
+	logger.currentDate = "2000-01-01"
+	logger.mu.Unlock()
+
+	_ = logger.Slogger()
+
+	logger.mu.Lock()
+	defer logger.mu.Unlock()
+	if logger.currentDate == "2000-01-01" {
+		t.Error("checkRotate() did not trigger rotation on date change")
+	}
+}
+
+func TestSlogger_WarnLevel(t *testing.T) {
+	tmpDir := t.TempDir()
+	logger, err := New(Config{Level: LevelWarn, LogDir: tmpDir})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer logger.Close()
+
+	s := logger.Slogger()
+	if s == nil {
+		t.Fatal("Slogger() returned nil")
+	}
+}
+
+func TestSlogger_ErrorLevel(t *testing.T) {
+	tmpDir := t.TempDir()
+	logger, err := New(Config{Level: LevelError, LogDir: tmpDir})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer logger.Close()
+
+	s := logger.Slogger()
+	if s == nil {
+		t.Fatal("Slogger() returned nil")
+	}
+}
+
+func TestCleanOldLogs(t *testing.T) {
+	tempDir := t.TempDir()
+
+	now := time.Now()
+	for i := 0; i < 12; i++ {
+		ts := now.AddDate(0, 0, -i)
+		name := fmt.Sprintf("ybdownloader-%s.log", ts.Format("2006-01-02"))
+		path := filepath.Join(tempDir, name)
+		if err := os.WriteFile(path, []byte("log"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		// Set mod time so ordering is deterministic
+		if err := os.Chtimes(path, ts, ts); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := Config{Level: LevelInfo, LogDir: tempDir, MaxAgeDays: 7}
+	logger, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer logger.Close()
+
+	logger.cleanOldLogs()
+
+	entries, _ := os.ReadDir(tempDir)
+	var logFiles []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			logFiles = append(logFiles, e.Name())
+		}
+	}
+	sort.Strings(logFiles)
+
+	// Files older than 7 days should be removed
+	for _, name := range logFiles {
+		info, _ := os.Stat(filepath.Join(tempDir, name))
+		if info.ModTime().Before(now.AddDate(0, 0, -7)) {
+			t.Errorf("old log file %s should have been deleted", name)
+		}
+	}
+}
+
+func TestNewLogger_RotatesExistingLog(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Create an existing log file for today
+	today := time.Now().Format("2006-01-02")
+	existingLog := filepath.Join(tempDir, "ybdownloader-"+today+".log")
+	if err := os.WriteFile(existingLog, []byte("old log content"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{Level: LevelInfo, LogDir: tempDir, MaxAgeDays: 7}
+	logger, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer logger.Close()
+
+	// The log file should still exist (appended, not rotated since same day)
+	if _, err := os.Stat(existingLog); os.IsNotExist(err) {
+		t.Error("today's log file should still exist")
+	}
+}
+
+func TestLogger_Close_NoFile(t *testing.T) {
+	l := &Logger{}
+	err := l.Close()
+	if err != nil {
+		t.Errorf("Close() on logger with no file should return nil, got %v", err)
+	}
+}
+
+func TestGlobal_Close_NoInit(t *testing.T) {
+	// Ensure global logger is nil
+	globalMu.Lock()
+	saved := globalLogger
+	globalLogger = nil
+	globalMu.Unlock()
+	defer func() {
+		globalMu.Lock()
+		globalLogger = saved
+		globalMu.Unlock()
+	}()
+
+	err := Close()
+	if err != nil {
+		t.Errorf("Close() with no global logger should return nil, got %v", err)
+	}
+}
+
+func TestL_NoInit(t *testing.T) {
+	globalMu.Lock()
+	saved := globalLogger
+	globalLogger = nil
+	globalMu.Unlock()
+	defer func() {
+		globalMu.Lock()
+		globalLogger = saved
+		globalMu.Unlock()
+	}()
+
+	logger := L()
+	if logger == nil {
+		t.Error("L() should return default slog.Logger when not initialized")
+	}
 }

--- a/internal/infra/queue/manager.go
+++ b/internal/infra/queue/manager.go
@@ -359,6 +359,13 @@ func (m *Manager) processDownload(id string) {
 		m.emitQueueUpdate(items)
 	}()
 
+	// Refresh save path from current settings so changes after enqueue take effect
+	if s, err := m.settings(); err == nil && s.DefaultSavePath != "" {
+		m.mu.Lock()
+		item.SavePath = s.DefaultSavePath
+		m.mu.Unlock()
+	}
+
 	// Fetch metadata if not present
 	if item.Metadata == nil {
 		m.updateItemState(id, core.StateFetchingMetadata, "")

--- a/internal/infra/queue/manager_test.go
+++ b/internal/infra/queue/manager_test.go
@@ -724,3 +724,44 @@ func TestManager_Shutdown_NoActiveDownloads(t *testing.T) {
 		t.Errorf("Expected 2 items, got %d", len(items))
 	}
 }
+
+func TestManager_ProcessDownload_RefreshesSavePath(t *testing.T) {
+	var capturedSavePath string
+	var mu sync.Mutex
+
+	mock := &mockDownloader{
+		downloadFunc: func(ctx context.Context, item *core.QueueItem, onProgress func(core.DownloadProgress)) error {
+			mu.Lock()
+			capturedSavePath = item.SavePath
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	currentPath := "/old/path"
+	getSettings := func() (*core.Settings, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		return &core.Settings{
+			MaxConcurrentDownloads: 2,
+			DefaultSavePath:        currentPath,
+		}, nil
+	}
+
+	m := New(mock, getSettings, func(string, interface{}) {})
+	m.AddItem("id1", "https://youtube.com/watch?v=test", core.FormatMP3, "/old/path")
+
+	mu.Lock()
+	currentPath = "/new/path"
+	mu.Unlock()
+
+	m.StartDownload("id1")
+
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if capturedSavePath != "/new/path" {
+		t.Errorf("SavePath = %q, want %q (should refresh from settings)", capturedSavePath, "/new/path")
+	}
+}

--- a/internal/infra/settings/store_test.go
+++ b/internal/infra/settings/store_test.go
@@ -386,3 +386,60 @@ func TestStore_ConcurrentReadWrite(t *testing.T) {
 		<-done
 	}
 }
+
+func TestSaveAndLoad_YtDlpFields(t *testing.T) {
+	store, _ := newTestStore(t)
+
+	custom := &core.Settings{
+		Version:                core.SettingsVersion,
+		DefaultSavePath:        "/custom/path",
+		DefaultFormat:          core.FormatMP3,
+		MaxConcurrentDownloads: 2,
+		DownloadBackend:        core.BackendBuiltin,
+		YtDlpPath:              "/custom/yt-dlp",
+		YtDlpExtraFlags:        []string{"--proxy", "http://example.com", "--cookies-from-browser", "firefox"},
+	}
+
+	if err := store.Save(custom); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	store.cache = nil
+
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if loaded.DownloadBackend != core.BackendBuiltin {
+		t.Errorf("DownloadBackend = %q, want %q", loaded.DownloadBackend, core.BackendBuiltin)
+	}
+	if loaded.YtDlpPath != "/custom/yt-dlp" {
+		t.Errorf("YtDlpPath = %q, want %q", loaded.YtDlpPath, "/custom/yt-dlp")
+	}
+	if len(loaded.YtDlpExtraFlags) != 4 {
+		t.Fatalf("YtDlpExtraFlags length = %d, want 4", len(loaded.YtDlpExtraFlags))
+	}
+	if loaded.YtDlpExtraFlags[0] != "--proxy" || loaded.YtDlpExtraFlags[1] != "http://example.com" {
+		t.Errorf("YtDlpExtraFlags = %v, want [--proxy http://example.com ...]", loaded.YtDlpExtraFlags)
+	}
+}
+
+func TestLoad_InvalidDownloadBackend(t *testing.T) {
+	store, tmpDir := newTestStore(t)
+
+	settingsPath := filepath.Join(tmpDir, "settings.json")
+	data := `{"version":2,"downloadBackend":"invalid","maxConcurrentDownloads":2}`
+	if err := os.WriteFile(settingsPath, []byte(data), 0644); err != nil {
+		t.Fatalf("failed to write settings file: %v", err)
+	}
+
+	settings, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if settings.DownloadBackend != core.BackendYtDlp {
+		t.Errorf("DownloadBackend = %q, want %q (normalized)", settings.DownloadBackend, core.BackendYtDlp)
+	}
+}

--- a/internal/infra/settings/store_test.go
+++ b/internal/infra/settings/store_test.go
@@ -443,3 +443,90 @@ func TestLoad_InvalidDownloadBackend(t *testing.T) {
 		t.Errorf("DownloadBackend = %q, want %q (normalized)", settings.DownloadBackend, core.BackendYtDlp)
 	}
 }
+
+type errMockFS struct {
+	mockFS
+	configDirErr error
+	ensureDirErr error
+}
+
+func (m *errMockFS) GetConfigDir() (string, error) {
+	if m.configDirErr != nil {
+		return "", m.configDirErr
+	}
+	return m.mockFS.GetConfigDir()
+}
+
+func (m *errMockFS) EnsureDir(path string) error {
+	if m.ensureDirErr != nil {
+		return m.ensureDirErr
+	}
+	return m.mockFS.EnsureDir(path)
+}
+
+func TestNewStore_ConfigDirError(t *testing.T) {
+	fs := &errMockFS{configDirErr: os.ErrPermission}
+	_, err := NewStore(fs)
+	if err == nil {
+		t.Fatal("NewStore() expected error when GetConfigDir fails")
+	}
+}
+
+func TestNewStore_EnsureDirError(t *testing.T) {
+	tmpDir := t.TempDir()
+	fs := &errMockFS{
+		mockFS:       mockFS{configDir: tmpDir, musicDir: filepath.Join(tmpDir, "Music")},
+		ensureDirErr: os.ErrPermission,
+	}
+	_, err := NewStore(fs)
+	if err == nil {
+		t.Fatal("NewStore() expected error when EnsureDir fails")
+	}
+}
+
+func TestLoad_FileReadError(t *testing.T) {
+	store, tmpDir := newTestStore(t)
+
+	settingsPath := filepath.Join(tmpDir, settingsFileName)
+	if err := os.MkdirAll(settingsPath, 0755); err != nil {
+		t.Fatalf("failed to create dir at settings path: %v", err)
+	}
+
+	_, err := store.Load()
+	if err == nil {
+		t.Fatal("Load() expected error for non-IsNotExist read failure")
+	}
+}
+
+func TestSave_WriteError(t *testing.T) {
+	store, tmpDir := newTestStore(t)
+
+	if err := os.RemoveAll(tmpDir); err != nil {
+		t.Fatalf("failed to remove config dir: %v", err)
+	}
+
+	settings := &core.Settings{
+		DefaultFormat:          core.FormatMP3,
+		MaxConcurrentDownloads: 2,
+		DownloadBackend:        core.BackendYtDlp,
+	}
+
+	err := store.Save(settings)
+	if err == nil {
+		t.Fatal("Save() expected error when config dir is removed")
+	}
+}
+
+func TestReset_RemoveError(t *testing.T) {
+	store, tmpDir := newTestStore(t)
+
+	settingsPath := filepath.Join(tmpDir, settingsFileName)
+	if err := os.MkdirAll(filepath.Join(settingsPath, "blocker"), 0755); err != nil {
+		t.Fatalf("failed to create blocking dir: %v", err)
+	}
+
+	err := store.Reset()
+	if err == nil {
+		t.Fatal("Reset() expected error when file path is a non-empty directory")
+	}
+}

--- a/internal/infra/updater/updater.go
+++ b/internal/infra/updater/updater.go
@@ -72,6 +72,7 @@ type Updater struct {
 	updateInfo     *UpdateInfo
 	downloadPath   string
 	onProgress     func(UpdateInfo)
+	baseURL        string // override GitHubAPIURL for testing; empty means use default
 }
 
 // NewUpdater creates a new Updater instance
@@ -149,7 +150,11 @@ func (u *Updater) CheckForUpdate(ctx context.Context) (*UpdateInfo, error) {
 
 // getLatestRelease fetches the latest release from GitHub
 func (u *Updater) getLatestRelease(ctx context.Context) (*GitHubRelease, error) {
-	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", GitHubAPIURL, GitHubOwner, GitHubRepo)
+	apiBase := GitHubAPIURL
+	if u.baseURL != "" {
+		apiBase = u.baseURL
+	}
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", apiBase, GitHubOwner, GitHubRepo)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {

--- a/internal/infra/updater/updater_test.go
+++ b/internal/infra/updater/updater_test.go
@@ -1273,6 +1273,127 @@ func TestUpdater_GitHubRelease_AllFields(t *testing.T) {
 	}
 }
 
+func TestCheckForUpdate_Available(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(GitHubRelease{
+			TagName: "v2.0.0",
+			Body:    "New release",
+			HTMLURL: "https://github.com/test/releases/v2.0.0",
+			Assets:  []GitHubAsset{},
+		})
+	}))
+	defer server.Close()
+
+	u := NewUpdater("1.0.0")
+	u.baseURL = server.URL
+	u.httpClient = server.Client()
+
+	info, err := u.CheckForUpdate(context.Background())
+	if err != nil {
+		t.Fatalf("CheckForUpdate() error = %v", err)
+	}
+	if info.Status != StatusAvailable {
+		t.Errorf("Status = %q, want %q", info.Status, StatusAvailable)
+	}
+	if info.LatestVersion != "2.0.0" {
+		t.Errorf("LatestVersion = %q, want %q", info.LatestVersion, "2.0.0")
+	}
+}
+
+func TestCheckForUpdate_UpToDate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(GitHubRelease{
+			TagName: "v1.0.0",
+			Body:    "Same version",
+			HTMLURL: "https://github.com/test/releases/v1.0.0",
+		})
+	}))
+	defer server.Close()
+
+	u := NewUpdater("1.0.0")
+	u.baseURL = server.URL
+	u.httpClient = server.Client()
+
+	info, err := u.CheckForUpdate(context.Background())
+	if err != nil {
+		t.Fatalf("CheckForUpdate() error = %v", err)
+	}
+	if info.Status != StatusUpToDate {
+		t.Errorf("Status = %q, want %q", info.Status, StatusUpToDate)
+	}
+}
+
+func TestCheckForUpdate_InvalidLatestVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(GitHubRelease{
+			TagName: "not-semver",
+		})
+	}))
+	defer server.Close()
+
+	u := NewUpdater("1.0.0")
+	u.baseURL = server.URL
+	u.httpClient = server.Client()
+
+	_, err := u.CheckForUpdate(context.Background())
+	if err == nil {
+		t.Error("expected error for invalid semver")
+	}
+}
+
+func TestCheckForUpdate_InvalidCurrentVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(GitHubRelease{
+			TagName: "v2.0.0",
+		})
+	}))
+	defer server.Close()
+
+	u := NewUpdater("not-valid-semver")
+	u.baseURL = server.URL
+	u.httpClient = server.Client()
+
+	info, err := u.CheckForUpdate(context.Background())
+	if err != nil {
+		t.Fatalf("CheckForUpdate() error = %v", err)
+	}
+	if info.Status != StatusAvailable {
+		t.Errorf("Status = %q, want %q", info.Status, StatusAvailable)
+	}
+}
+
+func TestGetLatestRelease_NotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	u := NewUpdater("1.0.0")
+	u.baseURL = server.URL
+	u.httpClient = server.Client()
+
+	_, err := u.CheckForUpdate(context.Background())
+	if err == nil {
+		t.Error("expected error for 404")
+	}
+}
+
+func TestGetLatestRelease_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	u := NewUpdater("1.0.0")
+	u.baseURL = server.URL
+	u.httpClient = server.Client()
+
+	_, err := u.CheckForUpdate(context.Background())
+	if err == nil {
+		t.Error("expected error for 500")
+	}
+}
+
 func TestUpdater_UpdateInfo_AllFields(t *testing.T) {
 	info := UpdateInfo{
 		CurrentVersion: "1.0.0",


### PR DESCRIPTION
- Fixes [https://github.com/teofanis/ybdownloader/issues/91](https://github.com/teofanis/ybdownloader/issues/91)
- Shows yt-dl settings only when that download is selected
- minor house keeping tidy-up and Ui adjustments
- enhanced test suite
