### PR TITLE
feat(ci): enhance Cloudflare deployment checks in GitHub Actions

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -80,7 +80,7 @@ jobs:
     name: Deploy
     needs: build
     if: >-
-      secrets.CLOUDFLARE_API_TOKEN != '' &&
+      vars.WEB_DEPLOY_ENABLED != 'false' &&
       (
         (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
         github.event_name == 'pull_request' ||
@@ -98,6 +98,19 @@ jobs:
           name: web-dist
           path: apps/web/dist
 
+      - name: Check Cloudflare secrets
+        id: deploy-ready
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          if [ -z "$CF_API_TOKEN" ] || [ -z "$CF_ACCOUNT_ID" ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Skipping Cloudflare deploy. Add CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID repository secrets."
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Resolve Pages branch
         id: pages-branch
         run: |
@@ -110,6 +123,7 @@ jobs:
           fi
 
       - name: Deploy to Cloudflare Pages
+        if: steps.deploy-ready.outputs.ready == 'true'
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
@@ -119,7 +133,7 @@ jobs:
           command: pages deploy apps/web/dist --project-name=${{ env.CF_PAGES_PROJECT }} --branch=${{ steps.pages-branch.outputs.branch }}
 
       - name: Comment PR preview URL
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.deploy-ready.outputs.ready == 'true'
         uses: actions/github-script@v7
         env:
           PREVIEW_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -51,7 +51,9 @@ CI is in `.github/workflows/web.yml`. It lints, builds, and deploys to Cloudflar
 - `develop` → build only, no deploy
 - `workflow_dispatch` → production, handy for a manual refresh
 
-If `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` are missing, the workflow still lint/builds; deploy just skips.
+If the Cloudflare secrets are missing, lint/build still run and deploy logs a warning and skips.
+
+Set repo variable `WEB_DEPLOY_ENABLED=false` to turn off all deploys (lint/build keep running).
 
 ### First-time Cloudflare setup
 


### PR DESCRIPTION
- Updated the deployment workflow to check for the presence of Cloudflare API secrets before proceeding with deployment.
- Introduced a new step to verify if the necessary secrets are set, logging a warning if they are missing.
- Added a repository variable `WEB_DEPLOY_ENABLED` to control deployment behavior, allowing users to disable deployments while keeping linting and building active.
- Updated README documentation to reflect these changes and clarify the deployment process.

These improvements ensure a more robust deployment process and better user guidance regarding Cloudflare configuration.