### PR TITLE
feat(desktop): startup update notifications, beta channel, and shared release utilities

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,6 @@
 # Minimal .npmrc — intentional.
 #
-# pnpm 10+ project settings (hoisting, trust policy, install scripts, …) live in
+# pnpm 11+ project settings (hoisting, trust policy, install scripts, …) live in
 # pnpm-workspace.yaml. Version pins:
 #   - Node: package.json → engines.node (enforced when engine-strict=true)
 #   - pnpm: package.json → packageManager (Corepack; enforced in preinstall)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ## [Unreleased]
 
 ### Added
+
 - yt-dlp as default download engine (replaces built-in Go library); switch to legacy built-in in Settings
 - Automatic yt-dlp download and management (like FFmpeg)
 - Deno auto-install for YouTube signature solving when needed
@@ -18,16 +19,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - Browse tab with YouTube search and trending videos
 - Settings panel with theme customization, language selection, and log level control
 - Auto-update checker with GitHub Releases integration
+- Startup update notification when a newer version is available
+- Opt-in beta/pre-release update channel (desktop app)
+- Markdown release notes in About tab; shared release helpers across desktop and web
 - Automatic FFmpeg download if not found on system
 - Support for 7 languages: English, German, Spanish, French, Portuguese, Bulgarian, Greek
 
 ### Changed
+
 - Complete rewrite from the original Electron-based version
 - Now uses Wails (Go + React) instead of Electron
 - New UI built with shadcn/ui components
 - State management migrated to Zustand
 
 ### Fixed
+
 - Various edge cases in download queue handling
 - FFmpeg path detection on different platforms
 
@@ -35,9 +41,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## Release History
 
-This project started as a rewrite of [ElectronYoutubeDownloader](https://github.com/teofanis/ElectronYoutubeDownloader). The first stable release is currently in development.
+This project started as a rewrite of [ElectronYoutubeDownloader](https://github.com/teofanis/ElectronYoutubeDownloader). Stable desktop releases use `v*` tags; browser extension releases use `ext-v*` tags.
 
 All releases can be found on the [releases page](https://github.com/teofanis/ybdownloader/releases).
 
 See the [commit history](https://github.com/teofanis/ybdownloader/commits/main) for detailed changes.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to YBDownloader
 
-Thanks for your interest in contributing! This project is a **pnpm monorepo** with a Wails desktop app, browser extension, and shared packages.
+Thanks for your interest in contributing! This project is a **pnpm monorepo** with a Wails desktop app, browser extension, marketing site, and shared packages.
 
 ## Getting Started
 
@@ -27,10 +27,10 @@ See the [README](README.md) for platform-specific dependencies (GTK/WebKit on Li
 
 **Use pnpm only.** npm and yarn are blocked via `only-allow` on install.
 
-| Tool         | Pin              | Where                                                |
-| ------------ | ---------------- | ---------------------------------------------------- |
-| Node.js 24+  | `engines.node`   | `package.json`                                       |
-| pnpm 10.12.1 | `packageManager` | `package.json` (Corepack; CI uses `corepack enable`) |
+| Tool        | Pin              | Where                                                |
+| ----------- | ---------------- | ---------------------------------------------------- |
+| Node.js 24+ | `engines.node`   | `package.json`                                       |
+| pnpm 11.5.3 | `packageManager` | `package.json` (Corepack; CI uses `corepack enable`) |
 
 Project pnpm settings (hoisting, supply chain) are in `pnpm-workspace.yaml`. `.npmrc` only sets `engine-strict=true`.
 
@@ -96,16 +96,16 @@ pnpm audit             # Dependency vulnerability scan (high+)
 
 We take dependency security seriously:
 
-| Control                   | Where                                        |
-| ------------------------- | -------------------------------------------- |
-| **pnpm only**             | `only-allow` + `engines.pnpm` in preinstall  |
-| **Corepack**              | `scripts/ensure-corepack.mjs` in preinstall  |
-| **Frozen lockfile in CI** | `pnpm install --frozen-lockfile`             |
-| **Audit in CI**           | `pnpm audit --audit-level=high`              |
-| **Release age (24h)**     | `minimumReleaseAge` in `pnpm-workspace.yaml` |
-| **Trust policy**          | `trustPolicy: no-downgrade`                  |
-| **Install scripts**       | `onlyBuiltDependencies` whitelist            |
-| **Dependabot**            | Weekly updates for Go, npm, GitHub Actions   |
+| Control                   | Where                                            |
+| ------------------------- | ------------------------------------------------ |
+| **pnpm only**             | `only-allow` + `engines.pnpm` in preinstall      |
+| **Corepack**              | `scripts/ensure-corepack.mjs` in preinstall      |
+| **Frozen lockfile in CI** | `pnpm install --frozen-lockfile`                 |
+| **Audit in CI**           | `pnpm audit --audit-level=high`                  |
+| **Release age (24h)**     | `minimumReleaseAge` in `pnpm-workspace.yaml`     |
+| **Trust policy**          | `trustPolicy: no-downgrade`                      |
+| **Install scripts**       | `allowBuilds` whitelist in `pnpm-workspace.yaml` |
+| **Dependabot**            | Weekly updates for Go, npm, GitHub Actions       |
 
 When adding dependencies:
 
@@ -143,9 +143,10 @@ When adding dependencies:
 apps/
 ├── desktop/          # Wails (Go + React UI)
 ├── extension/        # Plasmo browser extension
+├── web/              # Astro marketing site
 └── e2e/              # Playwright tests
 packages/
-├── shared/           # URLs, formats, deep links
+├── shared/           # URLs, formats, deep links, release helpers, markdown
 └── ui/               # Shared React components
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ When I discovered Wails, I wanted to see what a native Go backend with a React f
 - **Browse & Search** - Search YouTube or check trending videos directly in the app
 - **Standalone Converter** - Convert local media files using FFmpeg with pre-made presets
 - **Auto FFmpeg** - Don't have FFmpeg? The app will download it for you
-- **Auto Updates** - Check for updates from within the app
+- **Auto Updates** - Startup notification, opt-in beta/pre-release channel, and in-app download from GitHub Releases
 - **Themes** - Light/dark mode + accent color customization
 - **Localization** - English, German, Spanish, French, Portuguese, Bulgarian, Greek
 - **Cross-platform** - Linux, Windows, macOS
@@ -52,7 +52,7 @@ When I discovered Wails, I wanted to see what a native Go backend with a React f
 ### Prerequisites
 
 - Go 1.26+
-- Node.js 24+ and pnpm 10.12.1 (via [Corepack](https://nodejs.org/api/corepack.html))
+- Node.js 24+ and pnpm 11.5.3 (via [Corepack](https://nodejs.org/api/corepack.html); pinned in `packageManager`)
 - Wails CLI: `go install github.com/wailsapp/wails/v2/cmd/wails@latest`
 
 **Linux only:**
@@ -77,13 +77,14 @@ cd ybdownloader
 ./scripts/setup-dev.sh
 ```
 
-That script runs `corepack enable` and `corepack pnpm install`. Corepack **downloads the pnpm version** pinned in `package.json` (`packageManager`: `pnpm@10.12.1`) on first install — you do not install pnpm globally.
+That script runs `corepack enable` and `corepack pnpm install`. Corepack **downloads the pnpm version** pinned in `package.json` (`packageManager`: `pnpm@11.5.3`) on first install — you do not install pnpm globally.
 
 **Daily dev** (after setup):
 
 ```bash
 pnpm dev:desktop      # Wails desktop app (hot reload)
 pnpm dev:extension    # Plasmo extension dev server
+pnpm dev:web          # Marketing site (Astro, port 4321)
 pnpm test             # Go + JS unit tests
 pnpm e2e              # Playwright smoke tests (desktop UI + Wails mock)
 pnpm audit            # Dependency security audit (high+)
@@ -97,6 +98,7 @@ If you already ran `corepack enable` on this machine, `pnpm install` is enough. 
 
 ```bash
 pnpm build                    # JS packages via Turbo (desktop UI + extension)
+pnpm build:web                # Marketing site (apps/web/dist)
 pnpm build:desktop-ui           # Desktop frontend only (apps/desktop/frontend/dist)
 pnpm build:desktop              # Full Wails app for your platform (apps/desktop/build/bin/)
 pnpm build:extension            # Extension default target (Chrome MV3)
@@ -143,10 +145,11 @@ pnpm run lint:go    # Go only
 │   │   ├── internal/     # Domain, infra, app bindings
 │   │   └── frontend/     # Desktop UI (@ybdownload/desktop-ui)
 │   ├── extension/        # Browser extension (@ybdownload/extension)
+│   ├── web/              # Marketing site (@ybdownload/web)
 │   └── e2e/              # Playwright E2E tests
 ├── packages/
-│   ├── shared/           # URLs, formats, deep links, YouTube helpers
-│   └── ui/               # Shared React components (button, badge, cn)
+│   ├── shared/           # URLs, formats, deep links, release helpers, markdown
+│   └── ui/               # Shared React components (shadcn/ui)
 ├── pnpm-workspace.yaml
 └── turbo.json
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,12 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| latest  | :white_check_mark: |
-| < latest | :x:               |
+| Version  | Supported          |
+| -------- | ------------------ |
+| latest   | :white_check_mark: |
+| < latest | :x:                |
 
-Only the latest release receives security updates. If you're running an older version, please upgrade.
+Only the latest **stable** desktop release receives security updates. Pre-release/beta builds are opt-in and unsupported. If you're running an older version, please upgrade.
 
 ## Reporting a Vulnerability
 
@@ -18,6 +18,7 @@ If you discover a security vulnerability, please report it responsibly.
 Instead, email the maintainer directly at: **teofanis@users.noreply.github.com**
 
 Include:
+
 - Description of the vulnerability
 - Steps to reproduce
 - Potential impact
@@ -47,5 +48,4 @@ YBDownloader downloads and processes media files from the internet. A few things
 
 ## Updates
 
-The app includes an update checker that fetches release info from GitHub. Updates are not installed automatically—you're prompted to download and install manually.
-
+The app includes an update checker that fetches desktop release info from GitHub (stable by default; beta/pre-releases are opt-in in About → Updates). You are prompted to download and install manually — updates are never applied silently.

--- a/apps/desktop/frontend/src/App.tsx
+++ b/apps/desktop/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { useAppStore } from "@/store";
 import { getSettings } from "@/lib/api";
 import { applyThemeMode, applyAccentTheme, type ThemeMode } from "@/lib/themes";
 import { useWailsEvents } from "@/hooks/use-wails-events";
+import { useStartupUpdateCheck } from "@/hooks/use-startup-update-check";
 import { DownloadsTab } from "@/features/downloads/DownloadsTab";
 import { ConverterTab } from "@/features/converter/ConverterTab";
 import { BrowseTab } from "@/features/browse/BrowseTab";
@@ -38,6 +39,7 @@ export default function App() {
   );
 
   useWailsEvents();
+  useStartupUpdateCheck(isInitialized);
 
   useEffect(() => {
     if (isShowcase) {

--- a/apps/desktop/frontend/src/features/about/AboutTab.test.tsx
+++ b/apps/desktop/frontend/src/features/about/AboutTab.test.tsx
@@ -8,7 +8,19 @@ import {
 import { mockUpdateInfo } from "@/test/fixtures";
 import { AboutTab } from "./AboutTab";
 import * as api from "@/lib/api";
+import { useAppStore } from "@/store";
 import { BrowserOpenURL } from "../../../wailsjs/runtime/runtime";
+
+const mockSettings = {
+  version: 3,
+  defaultSavePath: "/music",
+  defaultFormat: "mp3",
+  defaultAudioQuality: "192",
+  defaultVideoQuality: "720p",
+  maxConcurrentDownloads: 2,
+  downloadBackend: "yt-dlp" as const,
+  updateChannel: "stable" as const,
+};
 
 vi.mock("@/lib/api", () => ({
   getAppVersion: vi.fn(),
@@ -17,12 +29,17 @@ vi.mock("@/lib/api", () => ({
   getUpdateInfo: vi.fn(),
   installUpdate: vi.fn(),
   openReleasePage: vi.fn(),
+  saveSettings: vi.fn(),
 }));
 
 describe("AboutTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useAppStore.setState({ updateInfo: null, settings: mockSettings });
     vi.mocked(api.getAppVersion).mockResolvedValue("1.2.3");
+    vi.mocked(api.getUpdateInfo).mockResolvedValue(
+      mockUpdateInfo({ status: "idle" })
+    );
     vi.mocked(api.checkForUpdate).mockResolvedValue(mockUpdateInfo());
   });
 
@@ -44,6 +61,27 @@ describe("AboutTab", () => {
     await waitFor(() => {
       expect(api.checkForUpdate).toHaveBeenCalled();
     });
+  });
+
+  it("shows download actions when update info is already in the store", async () => {
+    useAppStore.setState({
+      updateInfo: mockUpdateInfo({
+        status: "available",
+        latestVersion: "2.0.0",
+        releaseNotes: "Bug fixes",
+      }),
+    });
+
+    renderWithProviders(<AboutTab />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "about.update.downloadNow" })
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("button", { name: "about.update.checkNow" })
+    ).not.toBeInTheDocument();
   });
 
   it("falls back to opening release page in browser", async () => {

--- a/apps/desktop/frontend/src/features/about/AboutTab.test.tsx
+++ b/apps/desktop/frontend/src/features/about/AboutTab.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
 } from "@/test/test-utils";
 import { mockUpdateInfo } from "@/test/fixtures";
+import { mockToast } from "@/test/mocks";
 import { AboutTab } from "./AboutTab";
 import * as api from "@/lib/api";
 import { useAppStore } from "@/store";
@@ -106,6 +107,140 @@ describe("AboutTab", () => {
 
     await waitFor(() => {
       expect(BrowserOpenURL).toHaveBeenCalled();
+    });
+  });
+
+  it("hydrates update info from the backend when the store is idle", async () => {
+    const cached = mockUpdateInfo({
+      status: "available",
+      latestVersion: "2.0.0",
+    });
+    vi.mocked(api.getUpdateInfo).mockResolvedValue(cached);
+
+    renderWithProviders(<AboutTab />);
+
+    await waitFor(() => {
+      expect(useAppStore.getState().updateInfo).toEqual(cached);
+    });
+  });
+
+  it("skips backend hydration when update info is already cached", async () => {
+    useAppStore.setState({
+      updateInfo: mockUpdateInfo({
+        status: "available",
+        latestVersion: "2.0.0",
+      }),
+    });
+
+    renderWithProviders(<AboutTab />);
+
+    await waitFor(() => {
+      expect(api.getAppVersion).toHaveBeenCalled();
+    });
+    expect(api.getUpdateInfo).not.toHaveBeenCalled();
+  });
+
+  it("shows a toast when the app is up to date", async () => {
+    vi.mocked(api.checkForUpdate).mockResolvedValue(
+      mockUpdateInfo({ status: "up_to_date" })
+    );
+
+    renderWithProviders(<AboutTab />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "about.update.checkNow" })
+    );
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "about.update.upToDate",
+        })
+      );
+    });
+  });
+
+  it("shows a toast when an update is available after checking", async () => {
+    vi.mocked(api.checkForUpdate).mockResolvedValue(
+      mockUpdateInfo({ status: "available", latestVersion: "2.0.0" })
+    );
+
+    renderWithProviders(<AboutTab />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "about.update.checkNow" })
+    );
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "about.update.available",
+        })
+      );
+    });
+  });
+
+  it("saves the beta channel and rechecks for updates", async () => {
+    renderWithProviders(<AboutTab />);
+
+    fireEvent.click(screen.getByRole("switch"));
+
+    await waitFor(() => {
+      expect(api.saveSettings).toHaveBeenCalledWith(
+        expect.objectContaining({ updateChannel: "beta" })
+      );
+      expect(api.checkForUpdate).toHaveBeenCalled();
+    });
+  });
+
+  it("downloads and installs updates from the about tab", async () => {
+    useAppStore.setState({
+      updateInfo: mockUpdateInfo({
+        status: "available",
+        latestVersion: "2.0.0",
+      }),
+    });
+    vi.mocked(api.getUpdateInfo).mockResolvedValue(
+      mockUpdateInfo({ status: "ready", latestVersion: "2.0.0" })
+    );
+
+    renderWithProviders(<AboutTab />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "about.update.downloadNow" })
+    );
+
+    await waitFor(() => {
+      expect(api.downloadUpdate).toHaveBeenCalled();
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "about.update.downloadComplete",
+        })
+      );
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "about.update.installNow" })
+    );
+
+    await waitFor(() => {
+      expect(api.installUpdate).toHaveBeenCalled();
+    });
+  });
+
+  it("shows an error toast when update checks fail", async () => {
+    vi.mocked(api.checkForUpdate).mockRejectedValue(new Error("network down"));
+
+    renderWithProviders(<AboutTab />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "about.update.checkNow" })
+    );
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "errors.generic",
+          variant: "destructive",
+        })
+      );
     });
   });
 });

--- a/apps/desktop/frontend/src/features/about/AboutTab.tsx
+++ b/apps/desktop/frontend/src/features/about/AboutTab.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  normalizeUpdateChannel,
+  type UpdateChannel,
+} from "@ybdownload/shared/releases";
 import { useToast } from "@/hooks/use-toast";
+import { useAppStore } from "@/store";
 import * as api from "@/lib/api";
+import type { Settings } from "@/types";
 import { BrowserOpenURL } from "../../../wailsjs/runtime/runtime";
 import { AppInfoCard, UpdateCard, LinksCard, SupportCard } from "./components";
 import { formatVersion, GITHUB_RELEASES_URL } from "./utils";
@@ -9,15 +15,33 @@ import { formatVersion, GITHUB_RELEASES_URL } from "./utils";
 export function AboutTab() {
   const { t } = useTranslation();
   const { toast } = useToast();
+  const updateInfo = useAppStore((s) => s.updateInfo);
+  const setUpdateInfo = useAppStore((s) => s.setUpdateInfo);
+  const settings = useAppStore((s) => s.settings);
+  const setSettings = useAppStore((s) => s.setSettings);
 
   const [version, setVersion] = useState<string>("");
-  const [updateInfo, setUpdateInfo] = useState<api.UpdateInfo | null>(null);
   const [isChecking, setIsChecking] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
+  const [isSavingChannel, setIsSavingChannel] = useState(false);
+
+  const updateChannel = normalizeUpdateChannel(settings?.updateChannel);
 
   useEffect(() => {
     api.getAppVersion().then(setVersion).catch(console.error);
-  }, []);
+
+    const cached = useAppStore.getState().updateInfo;
+    if (cached && cached.status !== "idle") return;
+
+    api
+      .getUpdateInfo()
+      .then((info) => {
+        if (info.status !== "idle") {
+          setUpdateInfo(info);
+        }
+      })
+      .catch(console.error);
+  }, [setUpdateInfo]);
 
   const handleCheckUpdate = async () => {
     setIsChecking(true);
@@ -45,6 +69,30 @@ export function AboutTab() {
         variant: "destructive",
       });
     } finally {
+      setIsChecking(false);
+    }
+  };
+
+  const handleUpdateChannelChange = async (channel: UpdateChannel) => {
+    if (!settings || channel === updateChannel) return;
+
+    setIsSavingChannel(true);
+    setIsChecking(true);
+    try {
+      const nextSettings: Settings = { ...settings, updateChannel: channel };
+      await api.saveSettings(nextSettings);
+      setSettings(nextSettings);
+
+      const info = await api.checkForUpdate();
+      setUpdateInfo(info);
+    } catch (e) {
+      toast({
+        title: t("errors.generic"),
+        description: String(e),
+        variant: "destructive",
+      });
+    } finally {
+      setIsSavingChannel(false);
       setIsChecking(false);
     }
   };
@@ -102,19 +150,21 @@ export function AboutTab() {
       <UpdateCard
         version={version}
         updateInfo={updateInfo}
+        updateChannel={updateChannel}
         isChecking={isChecking}
         isDownloading={isDownloading}
+        isSavingChannel={isSavingChannel}
         onCheck={handleCheckUpdate}
         onDownload={handleDownloadUpdate}
         onInstall={handleInstallUpdate}
         onOpenReleasePage={handleOpenReleasePage}
+        onUpdateChannelChange={handleUpdateChannelChange}
       />
 
       <LinksCard />
 
       <SupportCard />
 
-      {/* Footer */}
       <div className="text-muted-foreground text-center text-sm">
         <p>{t("about.footer.madeWith")}</p>
         <p className="mt-1">{t("about.footer.license")}</p>

--- a/apps/desktop/frontend/src/features/about/components/AppInfoCard.test.tsx
+++ b/apps/desktop/frontend/src/features/about/components/AppInfoCard.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { renderWithProviders, screen } from "@/test/test-utils";
+import { AppInfoCard } from "./AppInfoCard";
+
+describe("AppInfoCard", () => {
+  it("renders the current version", () => {
+    renderWithProviders(<AppInfoCard version="1.2.3" hasUpdate={false} />);
+
+    expect(screen.getByText("v1.2.3")).toBeInTheDocument();
+  });
+
+  it("shows a prerelease badge for beta versions", () => {
+    renderWithProviders(
+      <AppInfoCard version="2.0.0-beta.1" hasUpdate={false} />
+    );
+
+    expect(
+      screen.getByText("about.update.prereleaseBadge")
+    ).toBeInTheDocument();
+  });
+
+  it("shows a new-version badge when an update is available", () => {
+    renderWithProviders(
+      <AppInfoCard version="1.2.3" hasUpdate={true} latestVersion="2.0.0" />
+    );
+
+    expect(screen.getByText("about.update.newVersion")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/frontend/src/features/about/components/AppInfoCard.tsx
+++ b/apps/desktop/frontend/src/features/about/components/AppInfoCard.tsx
@@ -7,6 +7,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@ybdownload/ui/card";
+import { isPrereleaseVersion } from "@ybdownload/shared/releases";
 import { Badge } from "@ybdownload/ui/badge";
 import { formatVersion } from "../utils";
 
@@ -39,6 +40,11 @@ export function AppInfoCard({
           <Badge variant="outline" className="px-3 py-1 text-base">
             v{formatVersion(version) || "..."}
           </Badge>
+          {isPrereleaseVersion(version) && (
+            <Badge variant="outline" className="text-xs">
+              {t("about.update.prereleaseBadge")}
+            </Badge>
+          )}
           {hasUpdate && latestVersion && (
             <Badge className="border-amber-500/30 bg-amber-500/10 text-amber-600">
               {t("about.update.newVersion", {

--- a/apps/desktop/frontend/src/features/about/components/ReleaseNotes.tsx
+++ b/apps/desktop/frontend/src/features/about/components/ReleaseNotes.tsx
@@ -1,0 +1,19 @@
+import { renderMarkdown } from "@ybdownload/shared/markdown";
+
+interface ReleaseNotesProps {
+  body: string;
+  className?: string;
+}
+
+/** Renders trusted GitHub release notes (same source as the website). */
+export function ReleaseNotes({ body, className }: ReleaseNotesProps) {
+  return (
+    <div
+      className={
+        className ??
+        "prose prose-sm prose-invert text-muted-foreground max-h-40 max-w-none overflow-auto text-sm"
+      }
+      dangerouslySetInnerHTML={{ __html: renderMarkdown(body) }}
+    />
+  );
+}

--- a/apps/desktop/frontend/src/features/about/components/UpdateCard.test.tsx
+++ b/apps/desktop/frontend/src/features/about/components/UpdateCard.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders, screen, fireEvent } from "@/test/test-utils";
+import { mockUpdateInfo } from "@/test/fixtures";
+import { UpdateCard } from "./UpdateCard";
+
+const defaultProps = {
+  version: "1.0.0",
+  updateInfo: null,
+  updateChannel: "stable" as const,
+  isChecking: false,
+  isDownloading: false,
+  isSavingChannel: false,
+  onCheck: vi.fn(),
+  onDownload: vi.fn(),
+  onInstall: vi.fn(),
+  onOpenReleasePage: vi.fn(),
+  onUpdateChannelChange: vi.fn(),
+};
+
+describe("UpdateCard", () => {
+  it("reflects the beta channel toggle state", () => {
+    renderWithProviders(<UpdateCard {...defaultProps} updateChannel="beta" />);
+
+    expect(screen.getByRole("switch")).toBeChecked();
+  });
+
+  it("requests a channel change when the beta toggle is clicked", () => {
+    const onUpdateChannelChange = vi.fn();
+    renderWithProviders(
+      <UpdateCard
+        {...defaultProps}
+        onUpdateChannelChange={onUpdateChannelChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onUpdateChannelChange).toHaveBeenCalledWith("beta");
+  });
+
+  it("shows a prerelease badge for beta updates", () => {
+    renderWithProviders(
+      <UpdateCard
+        {...defaultProps}
+        updateInfo={mockUpdateInfo({
+          status: "available",
+          latestVersion: "2.0.0-beta.1",
+          prerelease: true,
+        })}
+      />
+    );
+
+    expect(
+      screen.getByText("about.update.prereleaseBadge")
+    ).toBeInTheDocument();
+  });
+
+  it("shows download progress while downloading", () => {
+    renderWithProviders(
+      <UpdateCard
+        {...defaultProps}
+        updateInfo={mockUpdateInfo({
+          status: "downloading",
+          progress: 42,
+        })}
+      />
+    );
+
+    expect(screen.getByText("about.update.downloading")).toBeInTheDocument();
+    expect(screen.getByText("42%")).toBeInTheDocument();
+  });
+
+  it("shows install and release-note actions for ready and available states", () => {
+    const { rerender } = renderWithProviders(
+      <UpdateCard
+        {...defaultProps}
+        updateInfo={mockUpdateInfo({
+          status: "available",
+          latestVersion: "2.0.0",
+          releaseNotes: "## Fixes",
+        })}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "about.update.downloadNow" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("about.update.releaseNotes")).toBeInTheDocument();
+
+    rerender(
+      <UpdateCard
+        {...defaultProps}
+        updateInfo={mockUpdateInfo({ status: "ready", latestVersion: "2.0.0" })}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "about.update.installNow" })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/frontend/src/features/about/components/UpdateCard.tsx
+++ b/apps/desktop/frontend/src/features/about/components/UpdateCard.tsx
@@ -17,29 +17,40 @@ import {
   CardTitle,
 } from "@ybdownload/ui/card";
 import { Progress } from "@ybdownload/ui/progress";
+import { Switch } from "@ybdownload/ui/switch";
+import { Label } from "@ybdownload/ui/label";
+import { Badge } from "@ybdownload/ui/badge";
+import type { UpdateChannel } from "@ybdownload/shared/releases";
 import type { UpdateInfo } from "@/lib/api";
 import { formatVersion } from "../utils";
+import { ReleaseNotes } from "./ReleaseNotes";
 
 interface UpdateCardProps {
   version: string;
   updateInfo: UpdateInfo | null;
+  updateChannel: UpdateChannel;
   isChecking: boolean;
   isDownloading: boolean;
+  isSavingChannel: boolean;
   onCheck: () => void;
   onDownload: () => void;
   onInstall: () => void;
   onOpenReleasePage: () => void;
+  onUpdateChannelChange: (channel: UpdateChannel) => void;
 }
 
 export function UpdateCard({
   version,
   updateInfo,
+  updateChannel,
   isChecking,
   isDownloading,
+  isSavingChannel,
   onCheck,
   onDownload,
   onInstall,
   onOpenReleasePage,
+  onUpdateChannelChange,
 }: UpdateCardProps) {
   const { t } = useTranslation();
 
@@ -84,6 +95,25 @@ export function UpdateCard({
         <CardDescription>{t("about.update.description")}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
+        <div className="flex items-center justify-between gap-4 rounded-lg border p-4">
+          <div className="space-y-1">
+            <Label htmlFor="beta-updates" className="text-sm font-medium">
+              {t("about.update.betaChannel")}
+            </Label>
+            <p className="text-muted-foreground text-xs">
+              {t("about.update.betaChannelDesc")}
+            </p>
+          </div>
+          <Switch
+            id="beta-updates"
+            checked={updateChannel === "beta"}
+            disabled={isSavingChannel || isChecking}
+            onCheckedChange={(checked) =>
+              onUpdateChannelChange(checked ? "beta" : "stable")
+            }
+          />
+        </div>
+
         {/* Version info */}
         <div className="bg-muted/50 flex items-center justify-between rounded-lg p-4">
           <div>
@@ -99,9 +129,16 @@ export function UpdateCard({
               <p className="text-muted-foreground text-sm">
                 {t("about.update.latestVersion")}
               </p>
-              <p className="font-mono font-medium">
-                v{formatVersion(updateInfo.latestVersion)}
-              </p>
+              <div className="flex items-center justify-end gap-2">
+                <p className="font-mono font-medium">
+                  v{formatVersion(updateInfo.latestVersion)}
+                </p>
+                {updateInfo.prerelease && (
+                  <Badge variant="outline" className="text-xs">
+                    {t("about.update.prereleaseBadge")}
+                  </Badge>
+                )}
+              </div>
             </div>
           )}
         </div>
@@ -164,11 +201,7 @@ export function UpdateCard({
             <p className="mb-2 text-sm font-medium">
               {t("about.update.releaseNotes")}
             </p>
-            <div className="prose prose-sm prose-invert text-muted-foreground max-h-40 overflow-auto text-sm">
-              <pre className="font-sans whitespace-pre-wrap">
-                {updateInfo.releaseNotes}
-              </pre>
-            </div>
+            <ReleaseNotes body={updateInfo.releaseNotes} />
           </div>
         )}
       </CardContent>

--- a/apps/desktop/frontend/src/hooks/use-startup-update-check.test.ts
+++ b/apps/desktop/frontend/src/hooks/use-startup-update-check.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useStartupUpdateCheck } from "./use-startup-update-check";
+import { useAppStore } from "@/store";
+import { mockToast } from "@/test/mocks";
+import { mockUpdateInfo } from "@/test/fixtures";
+import * as api from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  checkForUpdate: vi.fn(),
+}));
+
+describe("useStartupUpdateCheck", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAppStore.setState({ activeTab: "downloads", updateInfo: null });
+    vi.mocked(api.checkForUpdate).mockResolvedValue(mockUpdateInfo());
+  });
+
+  it("checks for updates once when enabled", async () => {
+    renderHook(() => useStartupUpdateCheck(true));
+
+    await waitFor(() => {
+      expect(api.checkForUpdate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not check when disabled", async () => {
+    renderHook(() => useStartupUpdateCheck(false));
+
+    await waitFor(() => {
+      expect(api.checkForUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  it("shows a toast when an update is available", async () => {
+    vi.mocked(api.checkForUpdate).mockResolvedValue(
+      mockUpdateInfo({ status: "available", latestVersion: "2.0.0" })
+    );
+
+    renderHook(() => useStartupUpdateCheck(true));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "about.update.available",
+          description: expect.any(String),
+          action: expect.anything(),
+        })
+      );
+    });
+  });
+
+  it("does not show a toast when up to date", async () => {
+    renderHook(() => useStartupUpdateCheck(true));
+
+    await waitFor(() => {
+      expect(api.checkForUpdate).toHaveBeenCalled();
+    });
+
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("stores update info in global state", async () => {
+    const info = mockUpdateInfo({
+      status: "available",
+      latestVersion: "2.0.0",
+    });
+    vi.mocked(api.checkForUpdate).mockResolvedValue(info);
+
+    renderHook(() => useStartupUpdateCheck(true));
+
+    await waitFor(() => {
+      expect(useAppStore.getState().updateInfo).toEqual(info);
+    });
+  });
+
+  it("navigates to the about tab when the toast action is clicked", async () => {
+    vi.mocked(api.checkForUpdate).mockResolvedValue(
+      mockUpdateInfo({ status: "available", latestVersion: "2.0.0" })
+    );
+
+    renderHook(() => useStartupUpdateCheck(true));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalled();
+    });
+
+    const toastCall = mockToast.mock.calls[0]?.[0];
+    expect(toastCall?.action?.props.onClick).toBeTypeOf("function");
+    toastCall.action.props.onClick();
+
+    expect(useAppStore.getState().activeTab).toBe("about");
+  });
+});

--- a/apps/desktop/frontend/src/hooks/use-startup-update-check.test.ts
+++ b/apps/desktop/frontend/src/hooks/use-startup-update-check.test.ts
@@ -92,4 +92,38 @@ describe("useStartupUpdateCheck", () => {
 
     expect(useAppStore.getState().activeTab).toBe("about");
   });
+
+  it("logs failures without showing a toast", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(api.checkForUpdate).mockRejectedValue(new Error("offline"));
+
+    renderHook(() => useStartupUpdateCheck(true));
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Startup update check failed:",
+        expect.any(Error)
+      );
+    });
+    expect(mockToast).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("ignores late results after unmount", async () => {
+    let resolve!: (value: ReturnType<typeof mockUpdateInfo>) => void;
+    vi.mocked(api.checkForUpdate).mockReturnValue(
+      new Promise((res) => {
+        resolve = res;
+      })
+    );
+
+    const { unmount } = renderHook(() => useStartupUpdateCheck(true));
+    unmount();
+    resolve(mockUpdateInfo({ status: "available", latestVersion: "2.0.0" }));
+
+    await waitFor(() => {
+      expect(api.checkForUpdate).toHaveBeenCalled();
+    });
+    expect(mockToast).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/frontend/src/hooks/use-startup-update-check.tsx
+++ b/apps/desktop/frontend/src/hooks/use-startup-update-check.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { ToastAction } from "@ybdownload/ui/toast";
+import { useToast } from "@/hooks/use-toast";
+import { useAppStore } from "@/store";
+import * as api from "@/lib/api";
+import { formatVersion } from "@/features/about/utils";
+
+const isShowcase = import.meta.env.VITE_SHOWCASE === "1";
+
+/**
+ * Checks for app updates once after startup and notifies the user when one is available.
+ */
+export function useStartupUpdateCheck(enabled: boolean) {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  const setActiveTab = useAppStore((s) => s.setActiveTab);
+  const setUpdateInfo = useAppStore((s) => s.setUpdateInfo);
+  const hasChecked = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || isShowcase || hasChecked.current) return;
+    hasChecked.current = true;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const info = await api.checkForUpdate();
+        if (cancelled) return;
+
+        setUpdateInfo(info);
+
+        if (info.status !== "available") return;
+
+        const actionLabel = t("about.update.downloadNow");
+
+        toast({
+          title: t("about.update.available"),
+          description: t("about.update.availableDesc", {
+            version: formatVersion(info.latestVersion),
+          }),
+          action: (
+            <ToastAction
+              altText={actionLabel}
+              onClick={() => setActiveTab("about")}
+            >
+              {actionLabel}
+            </ToastAction>
+          ),
+        });
+      } catch (e) {
+        console.error("Startup update check failed:", e);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, toast, t, setActiveTab, setUpdateInfo]);
+}

--- a/apps/desktop/frontend/src/hooks/use-wails-events.ts
+++ b/apps/desktop/frontend/src/hooks/use-wails-events.ts
@@ -15,6 +15,7 @@ export function useWailsEvents() {
   const updateProgress = useAppStore((s) => s.updateProgress);
   const setQueueLoading = useAppStore((s) => s.setQueueLoading);
   const setActiveTab = useAppStore((s) => s.setActiveTab);
+  const setUpdateInfo = useAppStore((s) => s.setUpdateInfo);
   const { toast } = useToast();
 
   // Load initial queue from backend
@@ -100,6 +101,13 @@ export function useWailsEvents() {
           setActiveTab(tab);
         });
 
+        const unsub8 = rt.EventsOn(
+          api.Events.UPDATE_PROGRESS,
+          (info: api.UpdateInfo) => {
+            setUpdateInfo(info);
+          }
+        );
+
         cleanup = () => {
           unsub1();
           unsub2();
@@ -108,6 +116,7 @@ export function useWailsEvents() {
           unsub5();
           unsub6();
           unsub7();
+          unsub8();
         };
       } catch (e) {
         console.warn("Wails runtime unavailable:", e);
@@ -115,5 +124,5 @@ export function useWailsEvents() {
     })();
 
     return () => cleanup?.();
-  }, [setQueue, updateProgress, setActiveTab, toast]);
+  }, [setQueue, updateProgress, setActiveTab, setUpdateInfo, toast]);
 }

--- a/apps/desktop/frontend/src/locales/bg.json
+++ b/apps/desktop/frontend/src/locales/bg.json
@@ -293,7 +293,10 @@
       "availableDesc": "Версия {{version}} е налична за изтегляне",
       "newVersion": "v{{version}} налична",
       "downloadComplete": "Изтеглянето завърши",
-      "downloadCompleteDesc": "Обновлението е готово. Натиснете Инсталирай и рестартирай."
+      "downloadCompleteDesc": "Обновлението е готово. Натиснете Инсталирай и рестартирай.",
+      "betaChannel": "Получавай beta обновления",
+      "betaChannelDesc": "Ранен достъп до предварителни версии. Може да са нестабилни.",
+      "prereleaseBadge": "Предварителна версия"
     },
     "links": {
       "title": "Връзки и ресурси",

--- a/apps/desktop/frontend/src/locales/de.json
+++ b/apps/desktop/frontend/src/locales/de.json
@@ -293,7 +293,10 @@
       "availableDesc": "Version {{version}} steht zum Download bereit",
       "newVersion": "v{{version}} verfügbar",
       "downloadComplete": "Download abgeschlossen",
-      "downloadCompleteDesc": "Das Update ist bereit zur Installation. Klicke auf Installieren & Neustarten."
+      "downloadCompleteDesc": "Das Update ist bereit zur Installation. Klicke auf Installieren & Neustarten.",
+      "betaChannel": "Beta-Updates erhalten",
+      "betaChannelDesc": "Früher Zugang zu Vorabversionen. Diese Builds können instabil sein.",
+      "prereleaseBadge": "Vorabversion"
     },
     "links": {
       "title": "Links & Ressourcen",

--- a/apps/desktop/frontend/src/locales/el.json
+++ b/apps/desktop/frontend/src/locales/el.json
@@ -293,7 +293,10 @@
       "availableDesc": "Η έκδοση {{version}} είναι διαθέσιμη",
       "newVersion": "v{{version}} διαθέσιμη",
       "downloadComplete": "Η λήψη ολοκληρώθηκε",
-      "downloadCompleteDesc": "Η ενημέρωση είναι έτοιμη. Πατήστε Εγκατάσταση & επανεκκίνηση."
+      "downloadCompleteDesc": "Η ενημέρωση είναι έτοιμη. Πατήστε Εγκατάσταση & επανεκκίνηση.",
+      "betaChannel": "Λήψη beta ενημερώσεων",
+      "betaChannelDesc": "Πρόσβαση σε προεκδόσεις. Μπορεί να είναι ασταθείς.",
+      "prereleaseBadge": "Προέκδοση"
     },
     "links": {
       "title": "Σύνδεσμοι & πόροι",

--- a/apps/desktop/frontend/src/locales/en.json
+++ b/apps/desktop/frontend/src/locales/en.json
@@ -293,7 +293,10 @@
       "availableDesc": "Version {{version}} is available for download",
       "newVersion": "v{{version}} available",
       "downloadComplete": "Download Complete",
-      "downloadCompleteDesc": "The update is ready to install. Click Install & Restart to update."
+      "downloadCompleteDesc": "The update is ready to install. Click Install & Restart to update.",
+      "betaChannel": "Receive beta updates",
+      "betaChannelDesc": "Get early access to pre-releases. These builds may be unstable.",
+      "prereleaseBadge": "Pre-release"
     },
     "links": {
       "title": "Links & Resources",

--- a/apps/desktop/frontend/src/locales/es.json
+++ b/apps/desktop/frontend/src/locales/es.json
@@ -293,7 +293,10 @@
       "availableDesc": "La versión {{version}} está disponible para descargar",
       "newVersion": "v{{version}} disponible",
       "downloadComplete": "Descarga Completa",
-      "downloadCompleteDesc": "La actualización está lista para instalar. Haz clic en Instalar y Reiniciar."
+      "downloadCompleteDesc": "La actualización está lista para instalar. Haz clic en Instalar y Reiniciar.",
+      "betaChannel": "Recibir actualizaciones beta",
+      "betaChannelDesc": "Acceso anticipado a versiones preliminares. Pueden ser inestables.",
+      "prereleaseBadge": "Prelanzamiento"
     },
     "links": {
       "title": "Enlaces y Recursos",

--- a/apps/desktop/frontend/src/locales/fr.json
+++ b/apps/desktop/frontend/src/locales/fr.json
@@ -293,7 +293,10 @@
       "availableDesc": "La version {{version}} est disponible au téléchargement",
       "newVersion": "v{{version}} disponible",
       "downloadComplete": "Téléchargement Terminé",
-      "downloadCompleteDesc": "La mise à jour est prête à être installée. Cliquez sur Installer et Redémarrer."
+      "downloadCompleteDesc": "La mise à jour est prête à être installée. Cliquez sur Installer et Redémarrer.",
+      "betaChannel": "Recevoir les mises à jour bêta",
+      "betaChannelDesc": "Accès anticipé aux préversions. Ces versions peuvent être instables.",
+      "prereleaseBadge": "Préversion"
     },
     "links": {
       "title": "Liens et Ressources",

--- a/apps/desktop/frontend/src/locales/pt.json
+++ b/apps/desktop/frontend/src/locales/pt.json
@@ -293,7 +293,10 @@
       "availableDesc": "A versão {{version}} está disponível para download",
       "newVersion": "v{{version}} disponível",
       "downloadComplete": "Download Concluído",
-      "downloadCompleteDesc": "A atualização está pronta para instalar. Clique em Instalar e Reiniciar."
+      "downloadCompleteDesc": "A atualização está pronta para instalar. Clique em Instalar e Reiniciar.",
+      "betaChannel": "Receber atualizações beta",
+      "betaChannelDesc": "Acesso antecipado a pré-lançamentos. Estas versões podem ser instáveis.",
+      "prereleaseBadge": "Pré-lançamento"
     },
     "links": {
       "title": "Links e Recursos",

--- a/apps/desktop/frontend/src/store/index.test.ts
+++ b/apps/desktop/frontend/src/store/index.test.ts
@@ -24,6 +24,7 @@ describe("useAppStore", () => {
       browseSearchQuery: "",
       browseResults: [],
       browseActiveTab: "search",
+      updateInfo: null,
     });
   });
 
@@ -35,6 +36,27 @@ describe("useAppStore", () => {
     it("can be changed", () => {
       useAppStore.getState().setActiveTab("settings");
       expect(useAppStore.getState().activeTab).toBe("settings");
+    });
+  });
+
+  describe("updateInfo", () => {
+    it("defaults to null", () => {
+      expect(useAppStore.getState().updateInfo).toBeNull();
+    });
+
+    it("can be updated", () => {
+      const info = {
+        currentVersion: "1.0.0",
+        latestVersion: "2.0.0",
+        releaseNotes: "",
+        releaseUrl: "",
+        downloadUrl: "",
+        downloadSize: 0,
+        status: "available",
+        progress: 0,
+      };
+      useAppStore.getState().setUpdateInfo(info);
+      expect(useAppStore.getState().updateInfo).toEqual(info);
     });
   });
 

--- a/apps/desktop/frontend/src/store/index.ts
+++ b/apps/desktop/frontend/src/store/index.ts
@@ -5,6 +5,7 @@ import type {
   TabId,
   DownloadProgress,
   Format,
+  UpdateInfo,
 } from "@/types";
 import type { YouTubeSearchResult } from "@/lib/api";
 
@@ -29,6 +30,8 @@ interface AppStore {
   browseResults: YouTubeSearchResult[];
   browseActiveTab: "search" | "trending";
 
+  updateInfo: UpdateInfo | null;
+
   setActiveTab: (tab: TabId) => void;
   setInitialized: (v: boolean) => void;
   setError: (e: string | null) => void;
@@ -51,6 +54,7 @@ interface AppStore {
   setBrowseSearchQuery: (q: string) => void;
   setBrowseResults: (r: YouTubeSearchResult[]) => void;
   setBrowseActiveTab: (t: "search" | "trending") => void;
+  setUpdateInfo: (info: UpdateInfo | null) => void;
 }
 
 /**
@@ -73,6 +77,8 @@ export const useAppStore = create<AppStore>()((set) => ({
   browseSearchQuery: "",
   browseResults: [],
   browseActiveTab: "search",
+
+  updateInfo: null,
 
   setActiveTab: (activeTab) => set({ activeTab }),
   setInitialized: (isInitialized) => set({ isInitialized }),
@@ -111,4 +117,5 @@ export const useAppStore = create<AppStore>()((set) => ({
   setBrowseSearchQuery: (browseSearchQuery) => set({ browseSearchQuery }),
   setBrowseResults: (browseResults) => set({ browseResults }),
   setBrowseActiveTab: (browseActiveTab) => set({ browseActiveTab }),
+  setUpdateInfo: (updateInfo) => set({ updateInfo }),
 }));

--- a/apps/desktop/frontend/src/test/fixtures.ts
+++ b/apps/desktop/frontend/src/test/fixtures.ts
@@ -12,6 +12,7 @@ export function mockUpdateInfo(
     downloadSize: 0,
     status: "up_to_date",
     progress: 0,
+    prerelease: false,
     ...overrides,
   };
 }

--- a/apps/desktop/frontend/src/types/index.ts
+++ b/apps/desktop/frontend/src/types/index.ts
@@ -77,6 +77,7 @@ export interface Settings {
   themeMode?: string;
   accentColor?: string;
   logLevel?: string;
+  updateChannel?: "stable" | "beta";
 }
 
 export interface FFmpegStatus {
@@ -130,6 +131,7 @@ export interface UpdateInfo {
   downloadSize: number;
   status: string;
   progress: number;
+  prerelease?: boolean;
   error?: string;
 }
 

--- a/apps/desktop/frontend/wailsjs/go/models.ts
+++ b/apps/desktop/frontend/wailsjs/go/models.ts
@@ -324,6 +324,7 @@ export namespace core {
 	    themeMode?: string;
 	    accentColor?: string;
 	    logLevel?: string;
+	    updateChannel?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new Settings(source);
@@ -346,6 +347,7 @@ export namespace core {
 	        this.themeMode = source["themeMode"];
 	        this.accentColor = source["accentColor"];
 	        this.logLevel = source["logLevel"];
+	        this.updateChannel = source["updateChannel"];
 	    }
 	}
 	
@@ -402,6 +404,7 @@ export namespace updater {
 	    downloadSize: number;
 	    status: string;
 	    progress: number;
+	    prerelease: boolean;
 	    error?: string;
 	
 	    static createFrom(source: any = {}) {
@@ -418,6 +421,7 @@ export namespace updater {
 	        this.downloadSize = source["downloadSize"];
 	        this.status = source["status"];
 	        this.progress = source["progress"];
+	        this.prerelease = source["prerelease"];
 	        this.error = source["error"];
 	    }
 	}

--- a/apps/desktop/internal/app/app.go
+++ b/apps/desktop/internal/app/app.go
@@ -34,6 +34,7 @@ type YouTubeSearcher interface {
 // AppUpdater interface for update functionality.
 type AppUpdater interface {
 	SetProgressCallback(callback func(updater.UpdateInfo))
+	SetUpdateChannel(channel string)
 	CheckForUpdate(ctx context.Context) (*updater.UpdateInfo, error)
 	DownloadUpdate(ctx context.Context) (string, error)
 	InstallUpdate() error
@@ -306,6 +307,11 @@ func (a *App) SaveSettings(s *core.Settings) error {
 	if old == nil || old.LogLevel != s.LogLevel {
 		logging.SetGlobalLevel(logging.ParseLevel(s.LogLevel))
 		slog.Info("log level changed", "level", s.LogLevel)
+	}
+
+	if a.appUpdater != nil &&
+		(old == nil || old.UpdateChannel != s.UpdateChannel) {
+		a.syncUpdateChannel(s.UpdateChannel)
 	}
 
 	slog.Debug("settings saved")
@@ -871,12 +877,32 @@ func (a *App) CheckForUpdate() (*updater.UpdateInfo, error) {
 		return nil, core.NewAppError(core.ErrCodeGeneric, "Updater not initialized", nil)
 	}
 
+	a.syncUpdateChannelFromSettings()
+
 	// Set up progress callback to emit events
 	a.appUpdater.SetProgressCallback(func(info updater.UpdateInfo) {
 		a.emit("update:progress", info)
 	})
 
 	return a.appUpdater.CheckForUpdate(a.ctx)
+}
+
+func (a *App) syncUpdateChannelFromSettings() {
+	channel := core.UpdateChannelStable
+	if a.settingsStore != nil {
+		if settings, err := a.settingsStore.Load(); err == nil {
+			channel = settings.UpdateChannel
+		}
+	}
+	a.syncUpdateChannel(channel)
+}
+
+func (a *App) syncUpdateChannel(channel core.UpdateChannel) {
+	if channel == core.UpdateChannelBeta {
+		a.appUpdater.SetUpdateChannel(updater.UpdateChannelBeta)
+		return
+	}
+	a.appUpdater.SetUpdateChannel(updater.UpdateChannelStable)
 }
 
 // DownloadUpdate downloads the available update.

--- a/apps/desktop/internal/app/app_test.go
+++ b/apps/desktop/internal/app/app_test.go
@@ -407,6 +407,10 @@ func (m *mockAppUpdater) SetProgressCallback(callback func(updater.UpdateInfo)) 
 	// No-op for testing
 }
 
+func (m *mockAppUpdater) SetUpdateChannel(channel string) {
+	// No-op for testing
+}
+
 func (m *mockAppUpdater) CheckForUpdate(ctx context.Context) (*updater.UpdateInfo, error) {
 	if m.checkError != nil {
 		return nil, m.checkError

--- a/apps/desktop/internal/app/app_test.go
+++ b/apps/desktop/internal/app/app_test.go
@@ -390,6 +390,7 @@ type mockAppUpdater struct {
 	downloadPath     string
 	installError     error
 	openReleaseError error
+	updateChannel    string
 }
 
 func newMockAppUpdater() *mockAppUpdater {
@@ -408,7 +409,7 @@ func (m *mockAppUpdater) SetProgressCallback(callback func(updater.UpdateInfo)) 
 }
 
 func (m *mockAppUpdater) SetUpdateChannel(channel string) {
-	// No-op for testing
+	m.updateChannel = channel
 }
 
 func (m *mockAppUpdater) CheckForUpdate(ctx context.Context) (*updater.UpdateInfo, error) {
@@ -2134,6 +2135,88 @@ func TestApp_CheckForUpdate_Error(t *testing.T) {
 	_, err := app.CheckForUpdate()
 	if err == nil {
 		t.Error("expected error")
+	}
+}
+
+func TestApp_CheckForUpdate_SyncsBetaChannelFromSettings(t *testing.T) {
+	store := &mockSettingsStore{
+		settings: func() *core.Settings {
+			s := core.DefaultSettings("/tmp/test")
+			s.UpdateChannel = core.UpdateChannelBeta
+			return s
+		}(),
+	}
+	upd := newMockAppUpdater()
+	app := &App{
+		ctx:           context.Background(),
+		appUpdater:    upd,
+		settingsStore: store,
+	}
+
+	if _, err := app.CheckForUpdate(); err != nil {
+		t.Fatalf("CheckForUpdate() error = %v", err)
+	}
+	if upd.updateChannel != updater.UpdateChannelBeta {
+		t.Errorf("updateChannel = %q, want %q", upd.updateChannel, updater.UpdateChannelBeta)
+	}
+}
+
+func TestApp_CheckForUpdate_SyncsStableChannelFromSettings(t *testing.T) {
+	store := &mockSettingsStore{}
+	upd := newMockAppUpdater()
+	app := &App{
+		ctx:           context.Background(),
+		appUpdater:    upd,
+		settingsStore: store,
+	}
+
+	if _, err := app.CheckForUpdate(); err != nil {
+		t.Fatalf("CheckForUpdate() error = %v", err)
+	}
+	if upd.updateChannel != updater.UpdateChannelStable {
+		t.Errorf("updateChannel = %q, want %q", upd.updateChannel, updater.UpdateChannelStable)
+	}
+}
+
+func TestApp_SaveSettings_SyncsUpdateChannel(t *testing.T) {
+	store := &mockSettingsStore{}
+	upd := newMockAppUpdater()
+	app := &App{
+		settingsStore: store,
+		appUpdater:    upd,
+	}
+
+	settings := core.DefaultSettings("/tmp/test")
+	settings.UpdateChannel = core.UpdateChannelBeta
+	if err := app.SaveSettings(settings); err != nil {
+		t.Fatalf("SaveSettings() error = %v", err)
+	}
+	if upd.updateChannel != updater.UpdateChannelBeta {
+		t.Errorf("updateChannel = %q, want %q", upd.updateChannel, updater.UpdateChannelBeta)
+	}
+}
+
+func TestApp_SaveSettings_DoesNotResyncUnchangedUpdateChannel(t *testing.T) {
+	store := &mockSettingsStore{}
+	upd := newMockAppUpdater()
+	app := &App{
+		settingsStore: store,
+		appUpdater:    upd,
+	}
+
+	settings := core.DefaultSettings("/tmp/test")
+	settings.UpdateChannel = core.UpdateChannelBeta
+	if err := app.SaveSettings(settings); err != nil {
+		t.Fatalf("SaveSettings() error = %v", err)
+	}
+	upd.updateChannel = "stale"
+
+	settings.DefaultFormat = core.FormatMP4
+	if err := app.SaveSettings(settings); err != nil {
+		t.Fatalf("SaveSettings() error = %v", err)
+	}
+	if upd.updateChannel != "stale" {
+		t.Errorf("updateChannel = %q, want unchanged %q", upd.updateChannel, "stale")
 	}
 }
 

--- a/apps/desktop/internal/core/settings.go
+++ b/apps/desktop/internal/core/settings.go
@@ -1,6 +1,13 @@
 package core
 
-const SettingsVersion = 2
+const SettingsVersion = 3
+
+type UpdateChannel string
+
+const (
+	UpdateChannelStable UpdateChannel = "stable"
+	UpdateChannelBeta   UpdateChannel = "beta"
+)
 
 type Settings struct {
 	Version                int             `json:"version"`
@@ -18,6 +25,7 @@ type Settings struct {
 	ThemeMode              string          `json:"themeMode,omitempty"`
 	AccentColor            string          `json:"accentColor,omitempty"`
 	LogLevel               string          `json:"logLevel,omitempty"`
+	UpdateChannel          UpdateChannel   `json:"updateChannel,omitempty"`
 }
 
 func DefaultSettings(musicDir string) *Settings {
@@ -33,6 +41,7 @@ func DefaultSettings(musicDir string) *Settings {
 		ThemeMode:              "system",
 		AccentColor:            "purple",
 		LogLevel:               "info",
+		UpdateChannel:          UpdateChannelStable,
 	}
 }
 
@@ -47,6 +56,11 @@ func (s *Settings) Validate() error {
 	case BackendBuiltin, BackendYtDlp:
 	default:
 		s.DownloadBackend = BackendYtDlp
+	}
+	switch s.UpdateChannel {
+	case UpdateChannelStable, UpdateChannelBeta:
+	default:
+		s.UpdateChannel = UpdateChannelStable
 	}
 	return nil
 }

--- a/apps/desktop/internal/core/settings_test.go
+++ b/apps/desktop/internal/core/settings_test.go
@@ -35,6 +35,9 @@ func TestDefaultSettings(t *testing.T) {
 	if s.LogLevel != "info" {
 		t.Errorf("LogLevel = %q, want %q", s.LogLevel, "info")
 	}
+	if s.UpdateChannel != UpdateChannelStable {
+		t.Errorf("UpdateChannel = %q, want %q", s.UpdateChannel, UpdateChannelStable)
+	}
 }
 
 func TestSettings_Validate(t *testing.T) {
@@ -120,6 +123,31 @@ func TestSettings_Validate_DownloadBackend(t *testing.T) {
 			_ = s.Validate()
 			if s.DownloadBackend != tt.expected {
 				t.Errorf("DownloadBackend = %q, want %q", s.DownloadBackend, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSettings_Validate_UpdateChannel(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    UpdateChannel
+		expected UpdateChannel
+	}{
+		{"stable stays", UpdateChannelStable, UpdateChannelStable},
+		{"beta stays", UpdateChannelBeta, UpdateChannelBeta},
+		{"invalid normalizes to stable", UpdateChannel("nightly"), UpdateChannelStable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Settings{
+				UpdateChannel:          tt.input,
+				MaxConcurrentDownloads: 2,
+			}
+			_ = s.Validate()
+			if s.UpdateChannel != tt.expected {
+				t.Errorf("UpdateChannel = %q, want %q", s.UpdateChannel, tt.expected)
 			}
 		})
 	}

--- a/apps/desktop/internal/infra/settings/store.go
+++ b/apps/desktop/internal/infra/settings/store.go
@@ -149,6 +149,11 @@ func (s *Store) migrate(settings core.Settings) core.Settings {
 	if settings.Version < 2 {
 		settings.DownloadBackend = core.BackendYtDlp
 	}
+	if settings.Version < 3 {
+		if settings.UpdateChannel == "" {
+			settings.UpdateChannel = core.UpdateChannelStable
+		}
+	}
 
 	settings.Version = core.SettingsVersion
 	return settings

--- a/apps/desktop/internal/infra/updater/updater.go
+++ b/apps/desktop/internal/infra/updater/updater.go
@@ -20,6 +20,9 @@ const (
 	GitHubOwner  = "teofanis"
 	GitHubRepo   = "ybdownloader"
 	GitHubAPIURL = "https://api.github.com"
+
+	UpdateChannelStable = "stable"
+	UpdateChannelBeta   = "beta"
 )
 
 // UpdateStatus tracks where we are in the update process.
@@ -44,6 +47,7 @@ type UpdateInfo struct {
 	DownloadSize   int64        `json:"downloadSize"`
 	Status         UpdateStatus `json:"status"`
 	Progress       float64      `json:"progress"` // 0-100
+	Prerelease     bool         `json:"prerelease"`
 	Error          string       `json:"error,omitempty"`
 }
 
@@ -68,6 +72,7 @@ type GitHubAsset struct {
 // Updater checks GitHub releases and handles self-updates.
 type Updater struct {
 	currentVersion string
+	updateChannel  string
 	httpClient     *http.Client
 	updateInfo     *UpdateInfo
 	downloadPath   string
@@ -86,7 +91,17 @@ func NewUpdater(currentVersion string) *Updater {
 			CurrentVersion: currentVersion,
 			Status:         StatusIdle,
 		},
+		updateChannel: UpdateChannelStable,
 	}
+}
+
+// SetUpdateChannel configures whether stable or beta prereleases are checked.
+func (u *Updater) SetUpdateChannel(channel string) {
+	if channel == UpdateChannelBeta {
+		u.updateChannel = UpdateChannelBeta
+		return
+	}
+	u.updateChannel = UpdateChannelStable
 }
 
 // SetProgressCallback sets a callback function for progress updates
@@ -118,6 +133,7 @@ func (u *Updater) CheckForUpdate(ctx context.Context) (*UpdateInfo, error) {
 	u.updateInfo.LatestVersion = latestVersion
 	u.updateInfo.ReleaseNotes = release.Body
 	u.updateInfo.ReleaseURL = release.HTMLURL
+	u.updateInfo.Prerelease = release.Prerelease
 
 	// Compare versions
 	current, err := semver.Parse(u.currentVersion)
@@ -148,13 +164,38 @@ func (u *Updater) CheckForUpdate(ctx context.Context) (*UpdateInfo, error) {
 	return u.updateInfo, nil
 }
 
-// getLatestRelease fetches the latest release from GitHub
+// isDesktopRelease reports whether a GitHub tag is a desktop app release (v*, not ext-v*).
+func isDesktopRelease(tagName string) bool {
+	return strings.HasPrefix(tagName, "v") && !strings.HasPrefix(tagName, "ext-")
+}
+
+// selectDesktopRelease picks the newest GitHub release for the configured channel.
+func selectDesktopRelease(releases []GitHubRelease, channel string) *GitHubRelease {
+	for i := range releases {
+		release := &releases[i]
+		if release.Draft || !isDesktopRelease(release.TagName) {
+			continue
+		}
+		if channel == UpdateChannelBeta {
+			if release.Prerelease {
+				return release
+			}
+			continue
+		}
+		if !release.Prerelease {
+			return release
+		}
+	}
+	return nil
+}
+
+// getLatestRelease fetches the latest desktop release for the active update channel.
 func (u *Updater) getLatestRelease(ctx context.Context) (*GitHubRelease, error) {
 	apiBase := GitHubAPIURL
 	if u.baseURL != "" {
 		apiBase = u.baseURL
 	}
-	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", apiBase, GitHubOwner, GitHubRepo)
+	url := fmt.Sprintf("%s/repos/%s/%s/releases?per_page=30", apiBase, GitHubOwner, GitHubRepo)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
@@ -176,12 +217,20 @@ func (u *Updater) getLatestRelease(ctx context.Context) (*GitHubRelease, error) 
 		return nil, fmt.Errorf("GitHub API error: %d", resp.StatusCode)
 	}
 
-	var release GitHubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+	var releases []GitHubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
 		return nil, err
 	}
 
-	return &release, nil
+	release := selectDesktopRelease(releases, u.updateChannel)
+	if release == nil {
+		if u.updateChannel == UpdateChannelBeta {
+			return nil, fmt.Errorf("no desktop prereleases found")
+		}
+		return nil, fmt.Errorf("no desktop releases found")
+	}
+
+	return release, nil
 }
 
 // findDownloadAsset finds the appropriate download asset for the current platform

--- a/apps/desktop/internal/infra/updater/updater_test.go
+++ b/apps/desktop/internal/infra/updater/updater_test.go
@@ -28,6 +28,17 @@ func mockRelease(tagName string, assets []GitHubAsset) GitHubRelease {
 	}
 }
 
+func mockReleasesHandler(releases []GitHubRelease) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/releases") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(releases)
+	}
+}
+
 // mockAssets creates typical release assets for testing
 func mockAssets() []GitHubAsset {
 	return []GitHubAsset{
@@ -129,14 +140,7 @@ func TestUpdater_SetProgressCallback(t *testing.T) {
 func TestUpdater_CheckForUpdate_UpdateAvailable(t *testing.T) {
 	release := mockRelease("v2.0.0", mockAssets())
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/releases/latest") {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(release)
-			return
-		}
-		http.NotFound(w, r)
-	}))
+	server := httptest.NewServer(mockReleasesHandler([]GitHubRelease{release}))
 	defer server.Close()
 
 	u := NewUpdater("1.0.0")
@@ -635,11 +639,11 @@ func TestUpdater_IntegrationFlow(t *testing.T) {
 
 	// 2. Create mock server for both API and downloads
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/releases/latest") {
+		if strings.Contains(r.URL.Path, "/releases") {
 			// Update asset URL to point to our server
 			release.Assets[0].BrowserDownloadURL = "http://" + r.Host + "/download/binary"
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(release)
+			_ = json.NewEncoder(w).Encode([]GitHubRelease{release})
 			return
 		}
 
@@ -1274,14 +1278,12 @@ func TestUpdater_GitHubRelease_AllFields(t *testing.T) {
 }
 
 func TestCheckForUpdate_Available(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(GitHubRelease{
-			TagName: "v2.0.0",
-			Body:    "New release",
-			HTMLURL: "https://github.com/test/releases/v2.0.0",
-			Assets:  []GitHubAsset{},
-		})
-	}))
+	server := httptest.NewServer(mockReleasesHandler([]GitHubRelease{{
+		TagName: "v2.0.0",
+		Body:    "New release",
+		HTMLURL: "https://github.com/test/releases/v2.0.0",
+		Assets:  []GitHubAsset{},
+	}}))
 	defer server.Close()
 
 	u := NewUpdater("1.0.0")
@@ -1301,13 +1303,11 @@ func TestCheckForUpdate_Available(t *testing.T) {
 }
 
 func TestCheckForUpdate_UpToDate(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(GitHubRelease{
-			TagName: "v1.0.0",
-			Body:    "Same version",
-			HTMLURL: "https://github.com/test/releases/v1.0.0",
-		})
-	}))
+	server := httptest.NewServer(mockReleasesHandler([]GitHubRelease{{
+		TagName: "v1.0.0",
+		Body:    "Same version",
+		HTMLURL: "https://github.com/test/releases/v1.0.0",
+	}}))
 	defer server.Close()
 
 	u := NewUpdater("1.0.0")
@@ -1324,11 +1324,9 @@ func TestCheckForUpdate_UpToDate(t *testing.T) {
 }
 
 func TestCheckForUpdate_InvalidLatestVersion(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(GitHubRelease{
-			TagName: "not-semver",
-		})
-	}))
+	server := httptest.NewServer(mockReleasesHandler([]GitHubRelease{{
+		TagName: "vnot-semver",
+	}}))
 	defer server.Close()
 
 	u := NewUpdater("1.0.0")
@@ -1342,11 +1340,9 @@ func TestCheckForUpdate_InvalidLatestVersion(t *testing.T) {
 }
 
 func TestCheckForUpdate_InvalidCurrentVersion(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(GitHubRelease{
-			TagName: "v2.0.0",
-		})
-	}))
+	server := httptest.NewServer(mockReleasesHandler([]GitHubRelease{{
+		TagName: "v2.0.0",
+	}}))
 	defer server.Close()
 
 	u := NewUpdater("not-valid-semver")
@@ -1359,6 +1355,95 @@ func TestCheckForUpdate_InvalidCurrentVersion(t *testing.T) {
 	}
 	if info.Status != StatusAvailable {
 		t.Errorf("Status = %q, want %q", info.Status, StatusAvailable)
+	}
+}
+
+func TestIsDesktopRelease(t *testing.T) {
+	tests := []struct {
+		tag  string
+		want bool
+	}{
+		{"v1.0.2", true},
+		{"v1.0.0-beta.1", true},
+		{"ext-v0.0.4", false},
+		{"ext-v0.0.3", false},
+		{"1.0.0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			if got := isDesktopRelease(tt.tag); got != tt.want {
+				t.Errorf("isDesktopRelease(%q) = %v, want %v", tt.tag, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLatestRelease_SkipsExtensionReleases(t *testing.T) {
+	releases := []GitHubRelease{
+		mockRelease("ext-v0.0.4", nil),
+		mockRelease("v1.0.2", nil),
+	}
+
+	server := httptest.NewServer(mockReleasesHandler(releases))
+	defer server.Close()
+
+	u := NewUpdater("1.0.0")
+	u.baseURL = server.URL
+	u.httpClient = server.Client()
+
+	release, err := u.getLatestRelease(context.Background())
+	if err != nil {
+		t.Fatalf("getLatestRelease() error = %v", err)
+	}
+	if release.TagName != "v1.0.2" {
+		t.Errorf("TagName = %q, want %q", release.TagName, "v1.0.2")
+	}
+}
+
+func TestSelectDesktopRelease_BetaChannel(t *testing.T) {
+	releases := []GitHubRelease{
+		mockRelease("v1.0.2", nil),
+		{
+			TagName:    "v1.1.0-beta.1",
+			Prerelease: true,
+		},
+	}
+
+	stable := selectDesktopRelease(releases, UpdateChannelStable)
+	if stable == nil || stable.TagName != "v1.0.2" {
+		t.Fatalf("stable release = %v, want v1.0.2", stable)
+	}
+
+	beta := selectDesktopRelease(releases, UpdateChannelBeta)
+	if beta == nil || beta.TagName != "v1.1.0-beta.1" {
+		t.Fatalf("beta release = %v, want v1.1.0-beta.1", beta)
+	}
+}
+
+func TestGetLatestRelease_BetaChannel(t *testing.T) {
+	releases := []GitHubRelease{
+		mockRelease("v1.0.2", nil),
+		{
+			TagName:    "v1.1.0-beta.1",
+			Prerelease: true,
+		},
+	}
+
+	server := httptest.NewServer(mockReleasesHandler(releases))
+	defer server.Close()
+
+	u := NewUpdater("1.0.0")
+	u.baseURL = server.URL
+	u.httpClient = server.Client()
+	u.SetUpdateChannel(UpdateChannelBeta)
+
+	release, err := u.getLatestRelease(context.Background())
+	if err != nil {
+		t.Fatalf("getLatestRelease() error = %v", err)
+	}
+	if release.TagName != "v1.1.0-beta.1" {
+		t.Errorf("TagName = %q, want %q", release.TagName, "v1.1.0-beta.1")
 	}
 }
 

--- a/apps/desktop/internal/infra/updater/updater_test.go
+++ b/apps/desktop/internal/infra/updater/updater_test.go
@@ -1421,6 +1421,95 @@ func TestSelectDesktopRelease_BetaChannel(t *testing.T) {
 	}
 }
 
+func TestGetLatestRelease_BetaChannel_NoPrereleases(t *testing.T) {
+	releases := []GitHubRelease{
+		mockRelease("v1.0.2", nil),
+	}
+
+	server := httptest.NewServer(mockReleasesHandler(releases))
+	defer server.Close()
+
+	u := NewUpdater("1.0.0")
+	u.baseURL = server.URL
+	u.httpClient = server.Client()
+	u.SetUpdateChannel(UpdateChannelBeta)
+
+	_, err := u.getLatestRelease(context.Background())
+	if err == nil {
+		t.Fatal("expected error when beta channel has no prereleases")
+	}
+	if err.Error() != "no desktop prereleases found" {
+		t.Errorf("error = %q, want %q", err.Error(), "no desktop prereleases found")
+	}
+}
+
+func TestSetUpdateChannel_DefaultsToStable(t *testing.T) {
+	u := NewUpdater("1.0.0")
+	u.SetUpdateChannel(UpdateChannelBeta)
+	u.SetUpdateChannel("nightly")
+	if u.updateChannel != UpdateChannelStable {
+		t.Errorf("updateChannel = %q, want %q", u.updateChannel, UpdateChannelStable)
+	}
+}
+
+func TestCheckForUpdate_SetsPrereleaseFlag(t *testing.T) {
+	releases := []GitHubRelease{
+		{
+			TagName:    "v2.0.0-beta.1",
+			Prerelease: true,
+			Body:       "Beta release",
+			HTMLURL:    "https://github.com/releases/v2.0.0-beta.1",
+		},
+	}
+
+	server := httptest.NewServer(mockReleasesHandler(releases))
+	defer server.Close()
+
+	u := NewUpdater("1.0.0")
+	u.baseURL = server.URL
+	u.httpClient = server.Client()
+	u.SetUpdateChannel(UpdateChannelBeta)
+
+	info, err := u.CheckForUpdate(context.Background())
+	if err != nil {
+		t.Fatalf("CheckForUpdate() error = %v", err)
+	}
+	if !info.Prerelease {
+		t.Error("Prerelease should be true for beta release")
+	}
+	if info.Status != StatusAvailable {
+		t.Errorf("Status = %q, want %q", info.Status, StatusAvailable)
+	}
+}
+
+func TestCheckForUpdate_InvokesProgressCallback(t *testing.T) {
+	releases := []GitHubRelease{
+		mockRelease("v2.0.0", nil),
+	}
+
+	server := httptest.NewServer(mockReleasesHandler(releases))
+	defer server.Close()
+
+	u := NewUpdater("1.0.0")
+	u.baseURL = server.URL
+	u.httpClient = server.Client()
+
+	var progress []UpdateStatus
+	u.SetProgressCallback(func(info UpdateInfo) {
+		progress = append(progress, info.Status)
+	})
+
+	if _, err := u.CheckForUpdate(context.Background()); err != nil {
+		t.Fatalf("CheckForUpdate() error = %v", err)
+	}
+	if len(progress) < 2 {
+		t.Fatalf("expected multiple progress callbacks, got %d", len(progress))
+	}
+	if progress[0] != StatusChecking {
+		t.Errorf("first status = %q, want %q", progress[0], StatusChecking)
+	}
+}
+
 func TestGetLatestRelease_BetaChannel(t *testing.T) {
 	releases := []GitHubRelease{
 		mockRelease("v1.0.2", nil),

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -8,17 +8,17 @@ Marketing site for YBDownloader. Astro + Tailwind, package name `@ybdownload/web
 - `/download` — desktop installers
 - `/extension` — browser extension zips
 - `/changelog` — release notes
-- `/releases` — tags and assets
+- `/releases` — stable desktop releases and a separate pre-releases section (extension zips use `ext-v*` tags)
 - `/docs` — links into the main repo
 
-Versions and download URLs come from the GitHub Releases API when you build. Nothing hits the API at runtime. If the fetch fails, pages still link out to GitHub Releases.
+Versions and download URLs come from the GitHub Releases API when you build. Desktop tags (`v*`) are filtered from extension tags (`ext-v*`). The home and download pages use the latest **stable** desktop release only. If the fetch fails, pages still link out to GitHub Releases.
 
 ## Local dev
 
-From the repo root:
+From the repo root (first clone: run `./scripts/setup-dev.sh` instead of bare `pnpm install`):
 
 ```bash
-pnpm install
+./scripts/setup-dev.sh   # first time only
 pnpm dev:web
 ```
 

--- a/apps/web/src/components/ReleaseList.astro
+++ b/apps/web/src/components/ReleaseList.astro
@@ -5,9 +5,10 @@ import type { GitHubRelease } from "../lib/github";
 interface Props {
   releases: GitHubRelease[];
   emptyMessage: string;
+  prerelease?: boolean;
 }
 
-const { releases, emptyMessage } = Astro.props;
+const { releases, emptyMessage, prerelease = false } = Astro.props;
 ---
 
 {
@@ -23,6 +24,11 @@ const { releases, emptyMessage } = Astro.props;
             <div>
               <h3 class="font-display text-xl font-bold">
                 {release.name || release.tag_name}
+                {prerelease && (
+                  <span class="ml-2 rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-300">
+                    Pre-release
+                  </span>
+                )}
               </h3>
               <p class="mt-1 text-sm text-muted">
                 {formatVersion(release.tag_name)} ·{" "}

--- a/apps/web/src/lib/github.ts
+++ b/apps/web/src/lib/github.ts
@@ -1,3 +1,10 @@
+import {
+  isDesktopReleaseTag,
+  isExtensionReleaseTag,
+  partitionDesktopReleases,
+  selectLatestDesktopRelease,
+  type UpdateChannel,
+} from "@ybdownload/shared/releases";
 import { GITHUB_REPO_URL } from "@ybdownload/shared/urls";
 
 const REPO = GITHUB_REPO_URL.replace("https://github.com/", "");
@@ -37,13 +44,11 @@ async function fetchReleases(perPage = 20): Promise<GitHubRelease[]> {
 }
 
 export function isDesktopRelease(release: GitHubRelease): boolean {
-  return (
-    release.tag_name.startsWith("v") && !release.tag_name.startsWith("ext-")
-  );
+  return isDesktopReleaseTag(release.tag_name);
 }
 
 export function isExtensionRelease(release: GitHubRelease): boolean {
-  return release.tag_name.startsWith("ext-v");
+  return isExtensionReleaseTag(release.tag_name);
 }
 
 export async function getDesktopReleases(): Promise<GitHubRelease[]> {
@@ -56,14 +61,24 @@ export async function getExtensionReleases(): Promise<GitHubRelease[]> {
   return releases.filter(isExtensionRelease);
 }
 
-export async function getLatestDesktopRelease(): Promise<GitHubRelease | null> {
+export async function getLatestDesktopRelease(
+  channel: UpdateChannel = "stable"
+): Promise<GitHubRelease | null> {
   const releases = await getDesktopReleases();
-  return releases.find((release) => !release.prerelease) ?? releases[0] ?? null;
+  return selectLatestDesktopRelease(releases, channel);
+}
+
+export async function getDesktopReleaseSections(): Promise<{
+  stable: GitHubRelease[];
+  prerelease: GitHubRelease[];
+}> {
+  const releases = await getDesktopReleases();
+  return partitionDesktopReleases(releases);
 }
 
 export async function getLatestExtensionRelease(): Promise<GitHubRelease | null> {
   const releases = await getExtensionReleases();
-  return releases.find((release) => !release.prerelease) ?? releases[0] ?? null;
+  return releases.find((release) => !release.prerelease) ?? null;
 }
 
 export function findAsset(

--- a/apps/web/src/lib/markdown.ts
+++ b/apps/web/src/lib/markdown.ts
@@ -1,10 +1,1 @@
-import { marked } from "marked";
-
-marked.setOptions({
-  gfm: true,
-  breaks: false,
-});
-
-export function renderMarkdown(source: string): string {
-  return marked.parse(source, { async: false }) as string;
-}
+export { renderMarkdown } from "@ybdownload/shared/markdown";

--- a/apps/web/src/pages/docs.astro
+++ b/apps/web/src/pages/docs.astro
@@ -20,7 +20,9 @@ import { GITHUB_ISSUES_URL, GITHUB_REPO_URL } from "@ybdownload/shared/urls";
           Desktop app
         </h2>
         <ul class="mt-4 list-disc space-y-2 pl-5 text-muted">
-          <li>Requires Go 1.26+, Node 24+, pnpm 10.12+, and Wails CLI.</li>
+          <li>
+            Requires Go 1.26+, Node 24+, pnpm 11.5.3 (Corepack), and Wails CLI.
+          </li>
           <li>
             Clone the repo and run <code
               class="rounded bg-white/5 px-1 text-zinc-200"

--- a/apps/web/src/pages/releases.astro
+++ b/apps/web/src/pages/releases.astro
@@ -1,13 +1,11 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import ReleaseList from "../components/ReleaseList.astro";
-import { getDesktopReleases, getExtensionReleases } from "../lib/github";
+import { getDesktopReleaseSections, getExtensionReleases } from "../lib/github";
 import { GITHUB_RELEASES_URL } from "@ybdownload/shared/urls";
 
-const [desktop, extension] = await Promise.all([
-  getDesktopReleases(),
-  getExtensionReleases(),
-]);
+const [{ stable: desktopStable, prerelease: desktopPrerelease }, extension] =
+  await Promise.all([getDesktopReleaseSections(), getExtensionReleases()]);
 ---
 
 <BaseLayout
@@ -19,13 +17,13 @@ const [desktop, extension] = await Promise.all([
       Releases
     </h1>
     <p class="mt-4 text-muted">
-      Artifacts are on
+      Stable downloads are listed below. Pre-releases are early-access builds on
       <a
         href={GITHUB_RELEASES_URL}
         class="text-accent hover:text-accent-soft"
         rel="noopener noreferrer"
         target="_blank">GitHub Releases</a
-      >. This page mirrors the latest tags at build time.
+      >.
     </p>
 
     <div class="mt-12 space-y-16">
@@ -33,10 +31,28 @@ const [desktop, extension] = await Promise.all([
         <h2 class="font-display text-2xl font-bold">Desktop</h2>
         <div class="mt-6">
           <ReleaseList
-            releases={desktop}
-            emptyMessage="No desktop releases found. Check GitHub Releases directly."
+            releases={desktopStable}
+            emptyMessage="No stable desktop releases found. Check GitHub Releases directly."
           />
         </div>
+        {
+          desktopPrerelease.length > 0 && (
+            <div class="mt-10">
+              <h3 class="font-display text-lg font-semibold">Pre-releases</h3>
+              <p class="mt-2 text-sm text-muted">
+                Early-access desktop builds. Enable beta updates in the app
+                About tab to receive them automatically.
+              </p>
+              <div class="mt-4">
+                <ReleaseList
+                  releases={desktopPrerelease}
+                  emptyMessage="No pre-releases found."
+                  prerelease={true}
+                />
+              </div>
+            </div>
+          )
+        }
       </div>
       <div>
         <h2 class="font-display text-2xl font-bold">Extension</h2>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@11.5.3",
   "engines": {
     "node": ">=24.0.0",
-    "pnpm": ">=10.12.1"
+    "pnpm": ">=11.5.3"
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm && node scripts/ensure-corepack.mjs",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,7 +9,9 @@
     "./urls": "./src/urls.ts",
     "./deep-link": "./src/deep-link.ts",
     "./youtube": "./src/youtube.ts",
-    "./product": "./src/product.ts"
+    "./product": "./src/product.ts",
+    "./releases": "./src/releases.ts",
+    "./markdown": "./src/markdown.ts"
   },
   "scripts": {
     "type-check": "tsc --noEmit",
@@ -20,5 +22,8 @@
     "@ybdownload/tsconfig": "workspace:*",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
+  },
+  "dependencies": {
+    "marked": "^15.0.12"
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,3 +3,5 @@ export * from "./urls";
 export * from "./deep-link";
 export * from "./youtube";
 export * from "./product";
+export * from "./releases";
+export * from "./markdown";

--- a/packages/shared/src/markdown.test.ts
+++ b/packages/shared/src/markdown.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "./markdown";
+
+describe("renderMarkdown", () => {
+  it("renders basic markdown", () => {
+    const html = renderMarkdown("## Hello\n\n- one");
+    expect(html).toContain("<h2");
+    expect(html).toContain("Hello");
+    expect(html).toContain("<li>");
+  });
+});

--- a/packages/shared/src/markdown.ts
+++ b/packages/shared/src/markdown.ts
@@ -1,0 +1,10 @@
+import { marked } from "marked";
+
+marked.setOptions({
+  gfm: true,
+  breaks: false,
+});
+
+export function renderMarkdown(source: string): string {
+  return marked.parse(source, { async: false }) as string;
+}

--- a/packages/shared/src/releases.test.ts
+++ b/packages/shared/src/releases.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  isDesktopReleaseTag,
+  isExtensionReleaseTag,
+  isPrereleaseVersion,
+  matchesUpdateChannel,
+  partitionDesktopReleases,
+  selectLatestDesktopRelease,
+} from "./releases";
+
+const release = (tag_name: string, prerelease: boolean, draft = false) => ({
+  tag_name,
+  prerelease,
+  draft,
+});
+
+describe("releases", () => {
+  it("identifies desktop and extension tags", () => {
+    expect(isDesktopReleaseTag("v1.0.2")).toBe(true);
+    expect(isDesktopReleaseTag("v1.0.0-beta.1")).toBe(true);
+    expect(isDesktopReleaseTag("ext-v0.0.4")).toBe(false);
+    expect(isExtensionReleaseTag("ext-v0.0.4")).toBe(true);
+  });
+
+  it("detects prerelease versions", () => {
+    expect(isPrereleaseVersion("1.0.0-beta.1")).toBe(true);
+    expect(isPrereleaseVersion("v1.0.0-rc.1")).toBe(true);
+    expect(isPrereleaseVersion("1.0.0")).toBe(false);
+    expect(isPrereleaseVersion("0.0.0-dev")).toBe(false);
+  });
+
+  it("selects stable desktop releases and skips extensions", () => {
+    const releases = [
+      release("ext-v0.0.4", false),
+      release("v1.0.2", false),
+      release("v1.0.0-beta.1", true),
+    ];
+
+    expect(selectLatestDesktopRelease(releases, "stable")?.tag_name).toBe(
+      "v1.0.2",
+    );
+    expect(matchesUpdateChannel(releases[2], "stable")).toBe(false);
+    expect(matchesUpdateChannel(releases[2], "beta")).toBe(true);
+  });
+
+  it("selects beta channel prereleases only", () => {
+    const releases = [
+      release("v1.0.2", false),
+      release("v1.0.0-beta.2", true),
+      release("v1.0.0-beta.1", true),
+    ];
+
+    expect(selectLatestDesktopRelease(releases, "beta")?.tag_name).toBe(
+      "v1.0.0-beta.2",
+    );
+    expect(selectLatestDesktopRelease(releases, "stable")?.tag_name).toBe(
+      "v1.0.2",
+    );
+    expect(
+      selectLatestDesktopRelease([release("v1.0.2", false)], "beta"),
+    ).toBeNull();
+  });
+
+  it("partitions desktop releases", () => {
+    const releases = [
+      release("ext-v0.0.4", false),
+      release("v1.0.2", false),
+      release("v1.0.0-beta.1", true),
+    ];
+
+    const { stable, prerelease } = partitionDesktopReleases(releases);
+    expect(stable.map((r) => r.tag_name)).toEqual(["v1.0.2"]);
+    expect(prerelease.map((r) => r.tag_name)).toEqual(["v1.0.0-beta.1"]);
+  });
+});

--- a/packages/shared/src/releases.ts
+++ b/packages/shared/src/releases.ts
@@ -1,0 +1,71 @@
+export type UpdateChannel = "stable" | "beta";
+
+export const UPDATE_CHANNEL_STABLE: UpdateChannel = "stable";
+export const UPDATE_CHANNEL_BETA: UpdateChannel = "beta";
+
+export interface ReleaseLike {
+  tag_name: string;
+  prerelease: boolean;
+  draft?: boolean;
+}
+
+/** Desktop app tags: `v*` but not `ext-v*`. */
+export function isDesktopReleaseTag(tagName: string): boolean {
+  return tagName.startsWith("v") && !tagName.startsWith("ext-");
+}
+
+/** Browser extension tags: `ext-v*`. */
+export function isExtensionReleaseTag(tagName: string): boolean {
+  return tagName.startsWith("ext-v");
+}
+
+/** True when a version string contains beta/alpha/rc prerelease segments. */
+export function isPrereleaseVersion(version: string): boolean {
+  const normalized = version.replace(/^v/, "");
+  return /-(beta|alpha|rc)(\.|$|-)/i.test(normalized);
+}
+
+export function normalizeUpdateChannel(
+  channel: string | undefined,
+): UpdateChannel {
+  return channel === UPDATE_CHANNEL_BETA
+    ? UPDATE_CHANNEL_BETA
+    : UPDATE_CHANNEL_STABLE;
+}
+
+/** Whether a GitHub release matches the selected update channel. */
+export function matchesUpdateChannel(
+  release: ReleaseLike,
+  channel: UpdateChannel,
+): boolean {
+  if (release.draft) return false;
+  if (!isDesktopReleaseTag(release.tag_name)) return false;
+  return channel === UPDATE_CHANNEL_BETA
+    ? release.prerelease
+    : !release.prerelease;
+}
+
+/**
+ * Pick the newest matching desktop release (GitHub list is newest-first).
+ * Returns null when no stable/prerelease desktop release exists for the channel.
+ */
+export function selectLatestDesktopRelease<T extends ReleaseLike>(
+  releases: T[],
+  channel: UpdateChannel = UPDATE_CHANNEL_STABLE,
+): T | null {
+  return (
+    releases.find((release) => matchesUpdateChannel(release, channel)) ?? null
+  );
+}
+
+export function partitionDesktopReleases<T extends ReleaseLike>(
+  releases: T[],
+): { stable: T[]; prerelease: T[] } {
+  const desktop = releases.filter((release) =>
+    isDesktopReleaseTag(release.tag_name),
+  );
+  return {
+    stable: desktop.filter((release) => !release.prerelease),
+    prerelease: desktop.filter((release) => release.prerelease),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,6 +265,10 @@ importers:
   packages/config-typescript: {}
 
   packages/shared:
+    dependencies:
+      marked:
+        specifier: ^15.0.12
+        version: 15.0.12
     devDependencies:
       '@ybdownload/tsconfig':
         specifier: workspace:*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,7 +42,7 @@ trustPolicyExclude:
   - semver@5.7.2
   - semver@6.3.1
 
-# --- Supply chain hardening (pnpm 10+) ---
+# --- Supply chain hardening (pnpm 11+) ---
 # Delay installing freshly published package versions (24h).
 minimumReleaseAge: 1440
 minimumReleaseAgeStrict: false


### PR DESCRIPTION
## Summary

- Add shared release helpers (`isDesktopReleaseTag`, stable/beta channel selection) and markdown rendering used by desktop and web
- Fix desktop updater to ignore extension releases (`ext-v*`) and support opt-in beta/pre-release updates via settings
- Notify users on startup when a stable update is available, with a toast that links to the About tab
- Keep update state in the global store so About reflects startup checks without re-checking manually
- Improve About tab with beta toggle, markdown release notes, and prerelease badges
- Align website releases page: stable-only download surfaces, separate pre-release section with badges
