### PR TITLE
refactor(e2e): update regression test scripts and configurations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run regression tests
         uses: ./.github/actions/run-playwright-e2e
         with:
-          npm-script: test:regression
+          npm-script: test:regression:all
           artifact-prefix: e2e-regression
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/apps/e2e/README.md
+++ b/apps/e2e/README.md
@@ -53,13 +53,13 @@ We split tests into three tiers. The tier decides **when CI runs them**, not how
 
 **Folder:** `tests/downloads/`, `tests/settings/`, `tests/browse/`, etc. (create as we add suites).
 
-### Regression (no tag — everything)
+### Regression (desktop + extension on release)
 
-**What:** The entire Playwright suite in this package. Today that's the same as smoke; as we add `@full` tests, regression grows automatically.
+**What:** All desktop Playwright specs (`tests/` except `tests/extension/`) plus extension specs when using `test:regression:all` / `pnpm e2e:regression`.
 
-**When CI runs it:** Before any desktop release build — tag push `v*` or manual release workflow. If regression fails, Linux/Windows/macOS builds do not start.
+**When CI runs it:** Before any desktop release build — tag push `v*` or manual release workflow (`release.yml`). Extension CI runs `@extension` separately on PRs (`extension-ci.yml`).
 
-**Put a test here:** You don't tag for regression. Any spec file under `tests/` is included. Tag it `@smoke` or `@full` for the other tiers; regression always runs `playwright test` with no filter.
+**Put a test here:** You don't tag for regression. Desktop specs under `tests/smoke`, `tests/full`, etc. are included via `playwright test`. Extension specs live in `tests/extension/` and run via `playwright.extension.config.ts` (builds `chrome-mv3-prod` in global setup if missing).
 
 ---
 
@@ -73,12 +73,12 @@ Ask these in order:
 
 You can use extra tags for organisation (`@settings`, `@browse`, …) but CI only gates on `@smoke` and `@full` today.
 
-| Tag                     | CI                 |
-| ----------------------- | ------------------ |
-| `@smoke`                | PR smoke workflow  |
-| `@full`                 | Nightly            |
-| `@extension`            | Extension CI       |
-| (desktop `tests/` only) | Release regression |
+| Tag                   | CI                                       |
+| --------------------- | ---------------------------------------- |
+| `@smoke`              | PR smoke workflow                        |
+| `@full`               | Nightly                                  |
+| `@extension`          | Extension CI                             |
+| `test:regression:all` | Release regression (desktop + extension) |
 
 **Examples**
 
@@ -105,8 +105,8 @@ From the repo root:
 pnpm e2e:smoke        # what PR CI runs
 pnpm e2e:nightly      # smoke + full
 pnpm e2e:full         # @full only
-pnpm e2e:regression   # entire desktop suite (release gate)
-pnpm e2e:extension    # unpacked Chrome extension (@extension)
+pnpm e2e:regression   # desktop suite + extension (@extension); release gate
+pnpm e2e:extension    # extension only (@extension)
 pnpm e2e:ui           # Playwright UI mode
 ```
 

--- a/apps/e2e/helpers/extension-id.ts
+++ b/apps/e2e/helpers/extension-id.ts
@@ -6,6 +6,13 @@ import fs from "node:fs";
  * Used when the extension has no service worker (Plasmo popup + content scripts only).
  */
 export function extensionIdFromPath(extensionDir: string): string {
+  if (!fs.existsSync(extensionDir)) {
+    throw new Error(
+      `Extension build not found at ${extensionDir}. ` +
+        "Run pnpm build:extension, or use pnpm e2e:extension / test:regression:extension " +
+        "(global setup builds automatically).",
+    );
+  }
   const absolutePath = fs.realpathSync(extensionDir);
   const hash = crypto
     .createHash("sha256")

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -10,6 +10,8 @@
     "test:extension": "playwright test --config playwright.extension.config.ts",
     "test:nightly": "playwright test --grep \"@smoke|@full\"",
     "test:regression": "playwright test",
+    "test:regression:extension": "playwright test --config playwright.extension.config.ts",
+    "test:regression:all": "playwright test && playwright test --config playwright.extension.config.ts",
     "test:ui": "playwright test --ui",
     "test:headed": "playwright test --headed"
   },

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -6,6 +6,8 @@ const baseURL = `http://127.0.0.1:${PORT}`;
 
 export default defineConfig({
   testDir: "./tests",
+  // Extension specs need playwright.extension.config.ts (build + no Vite server).
+  testIgnore: ["**/extension/**"],
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "e2e:smoke": "pnpm --filter @ybdownload/e2e test:smoke",
     "e2e:nightly": "pnpm --filter @ybdownload/e2e test:nightly",
     "e2e:full": "pnpm --filter @ybdownload/e2e test:full",
-    "e2e:regression": "pnpm --filter @ybdownload/e2e test:regression",
+    "e2e:regression": "pnpm --filter @ybdownload/e2e test:regression:all",
     "e2e:extension": "pnpm --filter @ybdownload/e2e test:extension",
     "e2e:ui": "pnpm --filter @ybdownload/e2e test:ui"
   },


### PR DESCRIPTION
- Changed the regression test script to include all tests for both desktop and extension using `test:regression:all`.
- Updated the GitHub Actions workflow to reflect the new regression test command.
- Added new regression test commands for extension-specific tests.
- Modified Playwright configuration to ignore extension tests during regular runs.
- Enhanced documentation to clarify the regression testing process and CI triggers.

