### PR TITLE
feat(web): add live JSON integration and testing setup

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Lint site
         run: pnpm --filter @ybdownload/web lint
 
+      - name: Test site
+        run: pnpm --filter @ybdownload/web test
+
   build:
     name: Build
     needs: lint

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ apps/e2e/playwright-report/
 # --- apps/web (@ybdownload/web) ---
 apps/web/dist/
 apps/web/.astro/
+apps/web/public/live.json
 
 # --- packages ---
 packages/*/coverage/

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -13,6 +13,10 @@ Marketing site for YBDownloader. Astro + Tailwind, package name `@ybdownload/web
 
 Versions and download URLs come from the GitHub Releases API when you build. Desktop tags (`v*`) are filtered from extension tags (`ext-v*`). The home and download pages use the latest **stable** desktop release only. If the fetch fails, pages still link out to GitHub Releases.
 
+`public/live.json` is generated at build/dev start with star count and the latest desktop version. HTML keeps those values as no-JS fallbacks; a small client script refreshes them from `/live.json` using CDN stale-while-revalidate caching. Changelog and releases pages are still fully static and refresh on deploy (especially when a GitHub Release is published).
+
+Cache headers live in `public/_headers` (hashed assets immutable, HTML + `live.json` SWR).
+
 ## Local dev
 
 From the repo root (first clone: run `./scripts/setup-dev.sh` instead of bare `pnpm install`):

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -1,9 +1,10 @@
 import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
+import { liveJsonIntegration } from "./src/integrations/live-json.mjs";
 
 export default defineConfig({
   site: process.env.SITE_URL ?? "https://ybdownloader.pages.dev",
-  integrations: [tailwind({ applyBaseStyles: false })],
+  integrations: [tailwind({ applyBaseStyles: false }), liveJsonIntegration()],
   output: "static",
   compressHTML: true,
   build: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "build": "astro build",
     "preview": "astro preview --port 4321",
     "lint": "astro check && prettier --check .",
+    "test": "vitest run",
     "type-check": "astro check",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -28,8 +29,10 @@
     "prettier": "^3.8.3",
     "prettier-plugin-astro": "^0.14.1",
     "sharp": "^0.34.5",
+    "happy-dom": "^20.0.2",
     "tailwindcss": "^3.4.17",
     "typescript": "^6.0.3",
+    "vitest": "^4.1.8",
     "wrangler": "^4.100.0"
   }
 }

--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,0 +1,8 @@
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/live.json
+  Cache-Control: public, max-age=300, stale-while-revalidate=86400
+
+/*
+  Cache-Control: public, max-age=3600, stale-while-revalidate=604800

--- a/apps/web/src/components/GitHubStar.astro
+++ b/apps/web/src/components/GitHubStar.astro
@@ -26,6 +26,7 @@ const variantClass =
 <a
   href={GITHUB_REPO_URL}
   class:list={[baseClass, variantClass]}
+  data-live-stars-link
   rel="noopener noreferrer"
   target="_blank"
   aria-label={label}
@@ -43,7 +44,10 @@ const variantClass =
   <span>Star</span>
   {
     stars > 0 && (
-      <span class="rounded-full bg-canvas/80 px-2 py-0.5 text-xs font-medium text-amber-200/90">
+      <span
+        data-live-stars
+        class="min-w-[2.5rem] rounded-full bg-canvas/80 px-2 py-0.5 text-center text-xs font-medium tabular-nums text-amber-200/90"
+      >
         {formatStarCount(stars)}
       </span>
     )

--- a/apps/web/src/integrations/live-json.mjs
+++ b/apps/web/src/integrations/live-json.mjs
@@ -1,0 +1,29 @@
+import { fileURLToPath } from "node:url";
+import {
+  generateLiveJson,
+  writeLiveJsonFile,
+} from "../lib/generate-live-json.ts";
+
+/** @typedef {import('astro').AstroIntegration} AstroIntegration */
+
+/** @returns {AstroIntegration} */
+export function liveJsonIntegration() {
+  /** @type {import('node:url').URL | undefined} */
+  let projectRoot;
+
+  return {
+    name: "ybdownload-live-json",
+    hooks: {
+      "astro:config:done": (config) => {
+        projectRoot = config.root;
+      },
+      "astro:build:done": async ({ dir }) => {
+        await writeLiveJsonFile(fileURLToPath(new URL("live.json", dir)));
+      },
+      "astro:server:start": async () => {
+        if (!projectRoot) return;
+        await generateLiveJson(projectRoot);
+      },
+    },
+  };
+}

--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -136,5 +136,10 @@ const starCount = await getRepoStarCount();
         </div>
       </div>
     </footer>
+    <script>
+      import { scheduleLiveDataRefresh } from "../lib/live-client";
+
+      scheduleLiveDataRefresh();
+    </script>
   </body>
 </html>

--- a/apps/web/src/lib/generate-live-json.ts
+++ b/apps/web/src/lib/generate-live-json.ts
@@ -1,0 +1,30 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildLiveData, type LiveData } from "./live-data";
+import { getLatestDesktopRelease, getRepoStarCount } from "./github";
+
+export async function fetchLiveData(): Promise<LiveData> {
+  const [stars, latest] = await Promise.all([
+    getRepoStarCount(),
+    getLatestDesktopRelease(),
+  ]);
+
+  return buildLiveData(stars, latest?.tag_name ?? null);
+}
+
+export async function writeLiveJsonFile(outPath: string): Promise<void> {
+  const data = await fetchLiveData();
+  await mkdir(path.dirname(outPath), { recursive: true });
+  await writeFile(outPath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+export async function generateLiveJson(
+  projectRoot: string | URL
+): Promise<string> {
+  const root =
+    typeof projectRoot === "string" ? projectRoot : fileURLToPath(projectRoot);
+  const outPath = path.join(root, "public", "live.json");
+  await writeLiveJsonFile(outPath);
+  return outPath;
+}

--- a/apps/web/src/lib/live-client.ts
+++ b/apps/web/src/lib/live-client.ts
@@ -1,0 +1,43 @@
+import { site } from "../data/site";
+import { patchLiveData, type LiveData } from "./live-data";
+
+export async function refreshLiveData(): Promise<void> {
+  if (typeof document === "undefined") return;
+
+  try {
+    const response = await fetch("/live.json", {
+      credentials: "same-origin",
+      priority: "low",
+    });
+    if (!response.ok) return;
+
+    const data = (await response.json()) as LiveData;
+    if (
+      typeof data.stars !== "number" ||
+      typeof data.version !== "string" ||
+      typeof data.builtAt !== "string"
+    ) {
+      return;
+    }
+
+    patchLiveData(document, data, site.name);
+  } catch {
+    // Keep build-time fallbacks when live.json is unavailable.
+  }
+}
+
+/** Defer live refresh until after paint — live data is non-critical. */
+export function scheduleLiveDataRefresh(): void {
+  if (typeof window === "undefined") return;
+
+  const run = () => {
+    void refreshLiveData();
+  };
+
+  if ("requestIdleCallback" in window) {
+    window.requestIdleCallback(run, { timeout: 2_000 });
+    return;
+  }
+  // @ts-expect-error: window.setTimeout is not typed
+  window.setTimeout(run, 0);
+}

--- a/apps/web/src/lib/live-data.test.ts
+++ b/apps/web/src/lib/live-data.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLiveData,
+  desktopTitleLabel,
+  downloadCtaLabel,
+  patchLiveData,
+  starBadgeLabel,
+  starLinkAriaLabel,
+  type LiveDom,
+} from "./live-data";
+
+describe("buildLiveData", () => {
+  it("normalizes desktop tag and preserves stars", () => {
+    const data = buildLiveData(2400, "v1.4.0");
+
+    expect(data.stars).toBe(2400);
+    expect(data.version).toBe("1.4.0");
+    expect(data.builtAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("falls back to latest when no release tag is available", () => {
+    const data = buildLiveData(0, null);
+
+    expect(data.version).toBe("latest");
+  });
+});
+
+describe("live labels", () => {
+  it("formats download and desktop labels", () => {
+    expect(downloadCtaLabel("1.2.3")).toBe("Download v1.2.3");
+    expect(desktopTitleLabel("1.2.3")).toBe("Desktop app v1.2.3");
+    expect(starBadgeLabel(2400)).toBe("2.4k");
+    expect(starLinkAriaLabel("YBDownloader", 42)).toBe(
+      "Star YBDownloader on GitHub (42 stars)"
+    );
+  });
+});
+
+describe("patchLiveData", () => {
+  it("updates starred and version hooks in the document", () => {
+    const stars = document.createElement("span");
+    stars.setAttribute("data-live-stars", "");
+    stars.textContent = "1k";
+
+    const version = document.createElement("span");
+    version.setAttribute("data-live-version", "");
+    version.textContent = "1.0.0";
+
+    const cta = document.createElement("a");
+    cta.setAttribute("data-live-cta", "download");
+    cta.textContent = "Download v1.0.0";
+
+    const title = document.createElement("h1");
+    title.setAttribute("data-live-title", "desktop");
+    title.textContent = "Desktop app v1.0.0";
+
+    const link = document.createElement("a");
+    link.setAttribute("data-live-stars-link", "");
+    link.append(stars);
+
+    const root: LiveDom = {
+      querySelectorAll(selector: string) {
+        if (selector === "[data-live-stars]") return [stars];
+        if (selector === "[data-live-version]") return [version];
+        if (selector === '[data-live-cta="download"]') return [cta];
+        if (selector === '[data-live-title="desktop"]') return [title];
+        if (selector === "[data-live-stars-link]") return [link];
+        return [];
+      },
+    };
+
+    patchLiveData(
+      root,
+      {
+        stars: 2500,
+        version: "1.5.0",
+        builtAt: "2026-06-15T12:00:00.000Z",
+      },
+      "YBDownloader"
+    );
+
+    expect(stars.textContent).toBe("2.5k");
+    expect(version.textContent).toBe("1.5.0");
+    expect(cta.textContent).toBe("Download v1.5.0");
+    expect(title.textContent).toBe("Desktop app v1.5.0");
+    expect(link.getAttribute("aria-label")).toBe(
+      "Star YBDownloader on GitHub (2,500 stars)"
+    );
+  });
+
+  it("skips DOM writes when values are already current", () => {
+    const stars = document.createElement("span");
+    stars.setAttribute("data-live-stars", "");
+    stars.textContent = "2.5k";
+
+    const root: LiveDom = {
+      querySelectorAll(selector: string) {
+        if (selector === "[data-live-stars]") return [stars];
+        return [];
+      },
+    };
+
+    patchLiveData(
+      root,
+      {
+        stars: 2500,
+        version: "1.5.0",
+        builtAt: "2026-06-15T12:00:00.000Z",
+      },
+      "YBDownloader"
+    );
+
+    expect(stars.textContent).toBe("2.5k");
+  });
+});

--- a/apps/web/src/lib/live-data.ts
+++ b/apps/web/src/lib/live-data.ts
@@ -1,0 +1,82 @@
+import { formatVersion } from "@ybdownload/shared/urls";
+import { formatStarCount } from "./github";
+
+export interface LiveData {
+  stars: number;
+  version: string;
+  builtAt: string;
+}
+
+export function buildLiveData(stars: number, tagName: string | null): LiveData {
+  return {
+    stars,
+    version: tagName ? formatVersion(tagName) : "latest",
+    builtAt: new Date().toISOString(),
+  };
+}
+
+export function downloadCtaLabel(version: string): string {
+  return `Download v${version}`;
+}
+
+export function desktopTitleLabel(version: string): string {
+  return `Desktop app v${version}`;
+}
+
+export function starBadgeLabel(stars: number): string {
+  return formatStarCount(stars);
+}
+
+export function starLinkAriaLabel(appName: string, stars: number): string {
+  if (stars > 0) {
+    return `Star ${appName} on GitHub (${stars.toLocaleString("en-US")} stars)`;
+  }
+  return `Star ${appName} on GitHub`;
+}
+
+export interface LiveDom {
+  querySelectorAll(selector: string): Iterable<Element>;
+}
+
+function setTextIfChanged(element: Element, value: string): void {
+  if (element.textContent !== value) {
+    element.textContent = value;
+  }
+}
+
+function setAriaLabelIfChanged(element: Element, value: string): void {
+  if (element.getAttribute("aria-label") !== value) {
+    element.setAttribute("aria-label", value);
+  }
+}
+
+export function patchLiveData(
+  root: LiveDom,
+  data: LiveData,
+  appName: string
+): void {
+  const starsLabel = starBadgeLabel(data.stars);
+  const downloadLabel = downloadCtaLabel(data.version);
+  const desktopLabel = desktopTitleLabel(data.version);
+  const linkLabel = starLinkAriaLabel(appName, data.stars);
+
+  for (const element of root.querySelectorAll("[data-live-stars]")) {
+    setTextIfChanged(element, starsLabel);
+  }
+
+  for (const element of root.querySelectorAll("[data-live-version]")) {
+    setTextIfChanged(element, data.version);
+  }
+
+  for (const element of root.querySelectorAll('[data-live-cta="download"]')) {
+    setTextIfChanged(element, downloadLabel);
+  }
+
+  for (const element of root.querySelectorAll('[data-live-title="desktop"]')) {
+    setTextIfChanged(element, desktopLabel);
+  }
+
+  for (const link of root.querySelectorAll("[data-live-stars-link]")) {
+    setAriaLabelIfChanged(link, linkLabel);
+  }
+}

--- a/apps/web/src/pages/app.astro
+++ b/apps/web/src/pages/app.astro
@@ -41,6 +41,7 @@ const version = latest ? formatVersion(latest.tag_name) : "latest";
         <div class="mt-8 flex flex-wrap gap-4">
           <a
             href="/download"
+            data-live-cta="download"
             class="rounded-full bg-accent px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:bg-accent-soft"
           >
             Download v{version}

--- a/apps/web/src/pages/download.astro
+++ b/apps/web/src/pages/download.astro
@@ -24,7 +24,10 @@ const tarball = findAsset(latest, /\.tar\.gz$/i);
     <p class="text-sm font-semibold uppercase tracking-[0.2em] text-accent">
       Download
     </p>
-    <h1 class="mt-3 font-display text-4xl font-bold tracking-tight md:text-5xl">
+    <h1
+      data-live-title="desktop"
+      class="mt-3 font-display text-4xl font-bold tracking-tight md:text-5xl"
+    >
       Desktop app v{version}
     </h1>
     <p class="mt-4 max-w-2xl text-muted">

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -38,6 +38,7 @@ const version = latest ? formatVersion(latest.tag_name) : "latest";
         <div class="mt-8 flex flex-wrap gap-4">
           <a
             href="/download"
+            data-live-cta="download"
             class="rounded-full bg-accent px-6 py-3 text-sm font-semibold text-white shadow-glow transition hover:bg-accent-soft"
           >
             Download v{version}

--- a/apps/web/src/styles/global.css
+++ b/apps/web/src/styles/global.css
@@ -37,6 +37,13 @@
 }
 
 @layer components {
+  [data-live-stars],
+  [data-live-version],
+  [data-live-cta="download"],
+  [data-live-title="desktop"] {
+    font-variant-numeric: tabular-nums;
+  }
+
   .release-notes :where(a) {
     @apply text-accent underline-offset-2 hover:text-accent-soft hover:underline;
   }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.{test,spec}.ts"],
+    environment: "happy-dom",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
         version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0))
 
   apps/e2e:
     devDependencies:
@@ -219,6 +219,9 @@ importers:
       '@ybdownload/tsconfig':
         specifier: workspace:*
         version: link:../../packages/config-typescript
+      happy-dom:
+        specifier: ^20.0.2
+        version: 20.10.3
       prettier:
         specifier: ^3.8.3
         version: 3.8.4
@@ -234,6 +237,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0))
       wrangler:
         specifier: ^4.100.0
         version: 4.100.0
@@ -278,7 +284,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0))
 
   packages/ui:
     dependencies:
@@ -3254,6 +3260,12 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.61.0':
     resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3581,6 +3593,10 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
@@ -3972,6 +3988,10 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
@@ -4281,6 +4301,10 @@ packages:
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
+  happy-dom@20.10.3:
+    resolution: {integrity: sha512-Hjdiy8RziuCcn5z04QI/rlsNuQoG8P0xxjgvsSMpi89cvIXIOcucQtiHS1yHSShxoBcSCeYqAskINmTiy/mlfw==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -6480,6 +6504,10 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
@@ -6539,6 +6567,18 @@ packages:
 
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -9590,6 +9630,12 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.3
+
   '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -9700,7 +9746,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0))
+      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -9710,6 +9756,14 @@ snapshots:
       '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0))':
     dependencies:
@@ -10082,6 +10136,10 @@ snapshots:
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 25.9.3
+
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
@@ -10430,6 +10488,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   entities@8.0.0: {}
 
   env-paths@2.2.1: {}
@@ -10775,6 +10835,19 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.4
       uncrypto: 0.1.3
+
+  happy-dom@20.10.3:
+    dependencies:
+      '@types/node': 25.9.3
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -12999,6 +13072,22 @@ snapshots:
       sass: 1.101.0
       yaml: 2.9.0
 
+  vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.3
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      less: 4.6.4
+      sass: 1.101.0
+      yaml: 2.9.0
+
   vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -13019,7 +13108,37 @@ snapshots:
     optionalDependencies:
       vite: 7.3.5(@types/node@25.9.3)(jiti@1.21.7)(less@4.6.4)(lightningcss@1.32.0)(sass@1.101.0)(yaml@2.9.0)
 
-  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.2
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@1.21.7)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.3
+      '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      happy-dom: 20.10.3
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(happy-dom@20.10.3)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass@1.101.0)(yaml@2.9.0))
@@ -13044,6 +13163,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.3
       '@vitest/coverage-v8': 4.1.8(vitest@4.1.8)
+      happy-dom: 20.10.3
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
@@ -13174,6 +13294,8 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
+  whatwg-mimetype@3.0.0: {}
+
   whatwg-mimetype@5.0.0: {}
 
   whatwg-url@16.0.1:
@@ -13246,6 +13368,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   ws@8.20.1: {}
+
+  ws@8.21.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
- Implemented a new integration to generate and serve `public/live.json` with live data including GitHub star count and latest version.
- Updated the Astro configuration to include the new live JSON integration.
- Added a testing setup using Vitest for the live data functionality.
- Enhanced the web application to utilize live data in various components and pages.
- Introduced caching headers for `live.json` to optimize performance.
- Updated documentation to reflect changes in live data handling and local development setup.