### PR TITLE
feat(docs): enhance developer documentation and architecture overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ pnpm run lint:go    # Go only
 └── turbo.json
 ```
 
+**Architecture diagrams (Mermaid):** [GitHub Wiki](https://github.com/teofanis/ybdownload/wiki) — source in [`docs/wiki/`](docs/wiki/).
+
 ## Roadmap (Ideas)
 
 - [ ] Playlist support

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# Developer docs
+
+Architecture wiki — source files in `docs/wiki/`, published to [GitHub Wiki](https://github.com/teofanis/ybdownloader/wiki).
+
+| Wiki page              | File                                                                                     |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| Home                   | [wiki/Home.md](./wiki/Home.md)                                                           |
+| Monorepo               | [wiki/Architecture-Monorepo.md](./wiki/Architecture-Monorepo.md)                         |
+| Web                    | [wiki/Architecture-Web.md](./wiki/Architecture-Web.md)                                   |
+| Desktop                | [wiki/Architecture-Desktop.md](./wiki/Architecture-Desktop.md)                           |
+| Desktop updates        | [wiki/Architecture-Desktop-Updates.md](./wiki/Architecture-Desktop-Updates.md)           |
+| Extension & deep links | [wiki/Architecture-Extension-Deep-Links.md](./wiki/Architecture-Extension-Deep-Links.md) |
+| Releases & CI          | [wiki/Architecture-Releases-and-CI.md](./wiki/Architecture-Releases-and-CI.md)           |
+
+**Wiki** = how things connect (diagrams, pipelines). **App READMEs** = commands to build and run. Don't mix them.
+
+Copy `docs/wiki/*.md` to the wiki repo after changes on `main`. Enable wikis in [repo settings](https://github.com/teofanis/ybdownloader/settings) if needed.

--- a/docs/wiki/Architecture-Desktop-Updates.md
+++ b/docs/wiki/Architecture-Desktop-Updates.md
@@ -1,0 +1,50 @@
+# Desktop updates
+
+The app polls GitHub Releases for newer **`v*`** tags (ignores `ext-v*`). Stable channel = latest non-prerelease; beta = latest prerelease.
+
+Same channel rules as the web site — `packages/shared/src/releases.ts`.
+
+## Flow
+
+```mermaid
+flowchart LR
+  UI[About tab / startup toast] --> Check[CheckForUpdate]
+  Check --> GH[GitHub Releases API]
+  GH --> Pick[select by channel]
+  Pick --> Cmp[semver compare]
+  Cmp -->|newer| DL[DownloadUpdate]
+  DL --> Install[InstallUpdate → quit app]
+```
+
+## States
+
+`idle` → `checking` → `up_to_date` | `available` → `downloading` → `ready` → install quits the app.
+
+Errors land in `updateInfo.error`; user can retry from About.
+
+## Channels
+
+| Channel | Picks                                         |
+| ------- | --------------------------------------------- |
+| stable  | Newest `v*` release where `prerelease: false` |
+| beta    | Newest `v*` release where `prerelease: true`  |
+
+Toggle in About → saved in settings.
+
+## Install per OS
+
+- **Windows** — run downloaded installer or replace portable `.exe`
+- **macOS** — replace app in Applications
+- **Linux AppImage** — helper script copies new image after the app exits
+- **Linux tarball** — opens release page (manual)
+
+## Where in the code
+
+| File                                        | Role                   |
+| ------------------------------------------- | ---------------------- |
+| `internal/infra/updater/updater.go`         | API, download, install |
+| `internal/app/app.go`                       | Wails surface          |
+| `frontend/.../UpdateCard.tsx`               | About UI               |
+| `frontend/.../use-startup-update-check.tsx` | One check after launch |
+
+Cutting a release: [[Architecture-Releases-and-CI]].

--- a/docs/wiki/Architecture-Desktop.md
+++ b/docs/wiki/Architecture-Desktop.md
@@ -1,0 +1,82 @@
+# Desktop app
+
+Wails v2 app: Go backend in `internal/`, React UI in `frontend/`. The Go binary embeds `frontend/dist`.
+
+## Stack
+
+```mermaid
+flowchart TB
+  subgraph ui [React UI]
+    Tabs[Downloads / Browse / Convert / Settings / About]
+    Store[Zustand]
+    WailsJS[wailsjs bindings]
+  end
+
+  subgraph go [Go — internal/]
+    App[app.App]
+    Queue[queue.Manager]
+    DL[downloader]
+    Conv[converter]
+    Settings[settings]
+    Updater[updater]
+  end
+
+  subgraph proc [Child processes]
+    YTDLP[yt-dlp]
+    FFmpeg[ffmpeg]
+  end
+
+  Tabs --> Store --> WailsJS --> App
+  App --> Queue --> DL --> YTDLP
+  App --> Conv --> FFmpeg
+  Queue -->|EventsEmit| Store
+```
+
+## Layers
+
+| Layer    | Path              | Does                                                |
+| -------- | ----------------- | --------------------------------------------------- |
+| Frontend | `frontend/src/`   | UI, i18n, calls Go via Wails                        |
+| App      | `internal/app/`   | Wails methods, deep links, wires infra together     |
+| Core     | `internal/core/`  | Types, interfaces, settings model                   |
+| Infra    | `internal/infra/` | Queue, yt-dlp, FFmpeg, filesystem, updater, logging |
+
+## Download flow
+
+```mermaid
+sequenceDiagram
+  participant UI as React
+  participant App as app.App
+  participant Q as queue
+  participant D as downloader
+
+  UI->>App: AddToQueue(url, format)
+  App->>Q: enqueue
+  Q->>D: spawn yt-dlp
+  D-->>App: progress events
+  App-->>UI: Wails event → store
+```
+
+Default engine is **yt-dlp** (auto-downloaded). Legacy **kkdai/youtube** is still available in settings. **FFmpeg** is fetched on demand for conversion.
+
+Parallel download count comes from settings; the queue manager enforces it.
+
+## Talking to the frontend
+
+- **Sync:** generated bindings in `frontend/wailsjs/go/` — settings, queue, update check, etc.
+- **Async:** `runtime.EventsEmit` — download progress, deep-link results, converter status.
+
+## Deep links
+
+Single-instance app. A `ybdownloader://add?url=…&format=…` link focuses the window and enqueues the video. Platform-specific routing is in [[Architecture-Extension-Deep-Links]].
+
+## Build
+
+```bash
+pnpm dev:desktop          # hot reload
+pnpm build:desktop        # wails build → apps/desktop/build/bin/
+```
+
+Version is injected at link time: `-X main.Version=…`. Packaging notes: [apps/desktop/build/README](https://github.com/teofanis/ybdownloader/blob/main/apps/desktop/build/README.md).
+
+Updates: [[Architecture-Desktop-Updates]]. Releases: [[Architecture-Releases-and-CI]].

--- a/docs/wiki/Architecture-Extension-Deep-Links.md
+++ b/docs/wiki/Architecture-Extension-Deep-Links.md
@@ -1,0 +1,51 @@
+# Extension & deep links
+
+Plasmo extension (`apps/extension`). Injects a download button on YouTube; clicking it fires a deep link that opens the desktop app and enqueues the video.
+
+## Flow
+
+```mermaid
+flowchart LR
+  YT[YouTube page] --> Ext[content script]
+  Ext --> Link["ybdownloader://add?url=…"]
+  Link --> OS[OS protocol handler]
+  OS --> App[desktop app]
+  App --> Queue[download queue]
+```
+
+## Deep link format
+
+```
+ybdownloader://add?url=ENCODED_URL&format=mp3
+```
+
+| Param    | Required | Values                                          |
+| -------- | -------- | ----------------------------------------------- |
+| `url`    | yes      | Encoded YouTube URL                             |
+| `format` | no       | `mp3`, `mp4`, `webm` — defaults to app settings |
+
+Built in `packages/shared/src/deep-link.ts`. Extension and desktop must stay in sync if you change this.
+
+## Protocol registration
+
+| OS      | How                                                    |
+| ------- | ------------------------------------------------------ |
+| Windows | Installer registers handler                            |
+| macOS   | `OnUrlOpen` in Wails                                   |
+| Linux   | AppImageLauncher, or `install-protocol.sh` for tarball |
+
+Desktop side: `internal/app/app.go` (`handleDeepLink`, `OnSecondInstance`). Cold start on Win/Linux passes the URL via `os.Args`.
+
+## Build & release
+
+```bash
+pnpm dev:extension                              # → build/chrome-mv3-dev
+pnpm build:extension:release 1.0.0              # local zips
+git tag ext-v1.0.0 && git push origin ext-v1.0.0  # CI release
+```
+
+Targets: Chrome MV3, Firefox. Details: [apps/extension/README](https://github.com/teofanis/ybdownloader/blob/main/apps/extension/README.md).
+
+Sites: `youtube.com`, `music.youtube.com`.
+
+Desktop app: [[Architecture-Desktop]]. CI: [[Architecture-Releases-and-CI]].

--- a/docs/wiki/Architecture-Monorepo.md
+++ b/docs/wiki/Architecture-Monorepo.md
@@ -1,0 +1,68 @@
+# Monorepo
+
+pnpm workspace + Turborepo. One repo, four apps, a few shared packages.
+
+```mermaid
+flowchart TB
+  subgraph apps [apps/]
+    Desktop[desktop — Wails]
+    Extension[extension — Plasmo]
+    Web[web — Astro]
+    E2E[e2e — Playwright]
+  end
+
+  subgraph packages [packages/]
+    Shared[shared]
+    UI[ui]
+  end
+
+  Desktop --> Shared
+  Desktop --> UI
+  Extension --> Shared
+  Web --> Shared
+  E2E --> Desktop
+  E2E --> Extension
+```
+
+## Apps
+
+| App       | Ships as                            | Tag / deploy                  |
+| --------- | ----------------------------------- | ----------------------------- |
+| Desktop   | `.exe`, `.dmg`, AppImage, `.tar.gz` | `v*`                          |
+| Extension | Chrome + Firefox zips               | `ext-v*`                      |
+| Web       | Static `dist/` on Cloudflare Pages  | push `main` or GitHub Release |
+| E2E       | Nothing — CI only                   | —                             |
+
+## Shared packages
+
+- **`@ybdownload/shared`** — GitHub URLs, release tag rules (`v*` vs `ext-v*`), deep links, markdown helpers. Used by web, extension, and desktop UI.
+- **`@ybdownload/ui`** — shadcn components for the desktop app.
+- **`@ybdownload/tsconfig`** — shared TS config.
+
+Tag filtering lives in `packages/shared/src/releases.ts`. Web build, desktop updater, and changelog pages all use it — change it once, check all three.
+
+## Dev commands
+
+```bash
+./scripts/setup-dev.sh   # first clone
+pnpm dev:desktop
+pnpm dev:extension
+pnpm dev:web
+pnpm test
+pnpm e2e
+```
+
+## CI (short version)
+
+| Workflow                | When                        | What                                             |
+| ----------------------- | --------------------------- | ------------------------------------------------ |
+| `ci.yml`                | Every PR                    | Go + TS lint/test                                |
+| `release.yml`           | `v*` tag                    | E2E regression → desktop builds → GitHub Release |
+| `extension-release.yml` | `ext-v*` tag                | Extension zips → GitHub Release                  |
+| `web.yml`               | Web paths, `main`, releases | Lint, test, build, Cloudflare deploy             |
+
+Details: [[Architecture-Releases-and-CI]]. E2E layout: [apps/e2e/README](https://github.com/teofanis/ybdownloader/blob/main/apps/e2e/README.md).
+
+## What's not in this wiki
+
+Per-app build steps, env vars, and packaging notes stay in each app's README. This wiki is only the cross-cutting "how does it connect" stuff.

--- a/docs/wiki/Architecture-Releases-and-CI.md
+++ b/docs/wiki/Architecture-Releases-and-CI.md
@@ -1,0 +1,70 @@
+# Releases & CI
+
+Three separate shipping paths. They share GitHub Releases as the download host but use different tags.
+
+```mermaid
+flowchart LR
+  vTag[v* tag] --> R[release.yml]
+  extTag[ext-v* tag] --> E[extension-release.yml]
+  main[main / release event] --> W[web.yml]
+
+  R --> GH[GitHub Releases]
+  E --> GH
+  W --> CF[Cloudflare Pages]
+  GH -->|release published| W
+```
+
+## Desktop (`v*`)
+
+1. Push tag `v1.2.3`
+2. `release.yml` runs E2E regression (Playwright)
+3. Parallel builds: Linux, macOS, Windows
+4. `action-gh-release` uploads assets + changelog
+5. Triggers web production deploy
+
+Artifacts: installer, portable exe, dmg, AppImage, tarball. See release body template in `release.yml` for the full list.
+
+**Who reads this:** in-app updater, web site build, users on the Releases page.
+
+## Extension (`ext-v*`)
+
+1. Push tag `ext-v1.0.0`
+2. `extension-release.yml` bumps version, runs `package-extension-release.sh`
+3. Publishes Chrome + Firefox zips to GitHub Releases
+
+Extension version is independent of desktop (`ext-v1.0.0` alongside `v1.0.5` is normal).
+
+## Web
+
+`web.yml`: lint → test → `astro build` → Cloudflare Pages.
+
+| Trigger                  | Deploy?               |
+| ------------------------ | --------------------- |
+| PR (web paths)           | Preview URL on the PR |
+| `main`                   | Production            |
+| GitHub Release published | Production            |
+| `workflow_dispatch`      | Production            |
+| `develop`                | Build only            |
+
+Set `WEB_DEPLOY_ENABLED=false` to turn off deploys without killing CI.
+
+## Tag rules
+
+| Pattern             | Product   |
+| ------------------- | --------- |
+| `v*` (not `ext-v*`) | Desktop   |
+| `ext-v*`            | Extension |
+
+Logic in `packages/shared/src/releases.ts`.
+
+## PR CI (`ci.yml`)
+
+Go lint/test, desktop UI vitest, extension lint, shared package tests. E2E smoke on PRs; full regression only gates desktop **releases**.
+
+E2E details: [apps/e2e/README](https://github.com/teofanis/ybdownloader/blob/main/apps/e2e/README.md).
+
+## Related pages
+
+- [[Architecture-Web]] — what the web deploy picks up
+- [[Architecture-Desktop-Updates]] — how the app consumes `v*` releases
+- [[Architecture-Extension-Deep-Links]] — extension zip install

--- a/docs/wiki/Architecture-Web.md
+++ b/docs/wiki/Architecture-Web.md
@@ -1,0 +1,77 @@
+# Marketing site
+
+Static Astro site at `apps/web`. Built in CI, served from Cloudflare Pages. No server at runtime.
+
+Live site: [ybdownload.pages.dev](https://ybdownload.pages.dev)
+
+## How it works
+
+```mermaid
+flowchart TB
+  subgraph build [Build]
+    GH[GitHub API] --> Astro[Astro build]
+    Astro --> HTML[HTML + fallbacks]
+    Astro --> Assets[hashed /_astro/*]
+    GH --> LiveJSON[live.json]
+  end
+
+  subgraph cdn [Cloudflare CDN]
+    HTML --> CacheHTML[HTML + SWR]
+    Assets --> CacheAssets[immutable]
+    LiveJSON --> CacheLive[live.json + SWR]
+  end
+
+  subgraph browser [Browser]
+    CacheHTML --> Paint[first paint]
+    Paint --> Idle[idle fetch live.json]
+    Idle --> Patch[patch stars + version]
+  end
+```
+
+Most content is baked into HTML at build time (GitHub Releases API). Only star count and the version badge also refresh client-side via a small `live.json` file — so the site stays fast between deploys without going dynamic.
+
+## Routes
+
+| Route                         | Built from               | Refreshes                             |
+| ----------------------------- | ------------------------ | ------------------------------------- |
+| `/`, `/download`              | GitHub API + static copy | Deploy + `live.json` between deploys  |
+| `/changelog`, `/releases`     | Full release lists       | Deploy only (too big for `live.json`) |
+| `/extension`, `/app`, `/docs` | Static markdown/data     | Deploy on `main`                      |
+
+## `live.json`
+
+Generated at build (`astro:build:done`). Patched in the browser after paint via `data-live-*` hooks:
+
+- `[data-live-stars]` — star badge
+- `[data-live-cta="download"]` — "Download v…" buttons
+- `[data-live-title="desktop"]` — download page title
+
+HTML always has fallback values (works without JS).
+
+## Cache headers (`public/_headers`)
+
+```
+/_astro/*   immutable, 1 year
+/live.json  5 min fresh, 24h stale-while-revalidate
+/*          1h fresh, 7d stale-while-revalidate
+```
+
+## Deploys (`web.yml`)
+
+Production: push to `main` (web paths), publish a GitHub Release, or `workflow_dispatch`. PRs get a Cloudflare preview URL.
+
+Publishing a desktop/extension release also triggers a web rebuild so changelog and download links stay current.
+
+## Files worth knowing
+
+| File                            | What                          |
+| ------------------------------- | ----------------------------- |
+| `src/lib/github.ts`             | Fetch releases/stars at build |
+| `src/lib/generate-live-json.ts` | Write `dist/live.json`        |
+| `src/lib/live-client.ts`        | Browser fetch + patch         |
+| `public/_headers`               | CDN cache rules               |
+| `.github/workflows/web.yml`     | CI/CD                         |
+
+Run/build: [apps/web/README](https://github.com/teofanis/ybdownloader/blob/main/apps/web/README.md).
+
+Releases: [[Architecture-Releases-and-CI]].

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,46 @@
+# Developer wiki
+
+How the repo fits together — data flow, deploys, and where to look when you change something.
+
+Diagrams are Mermaid (render on GitHub Wiki and in the IDE).
+
+## Pages
+
+| Page                                  | Read this when…                                       |
+| ------------------------------------- | ----------------------------------------------------- |
+| [[Architecture-Monorepo]]             | You're new to the repo or need the big picture        |
+| [[Architecture-Web]]                  | You touch the marketing site, caching, or `live.json` |
+| [[Architecture-Desktop]]              | You work on the Wails app, queue, or downloads        |
+| [[Architecture-Desktop-Updates]]      | You change in-app updates or release channels         |
+| [[Architecture-Extension-Deep-Links]] | You work on the extension or `ybdownloader://` links  |
+| [[Architecture-Releases-and-CI]]      | You cut a release or debug CI                         |
+
+## What lives where
+
+| Location                                                                                  | Purpose                                                  |
+| ----------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| **`docs/wiki/`** (this wiki)                                                              | Architecture — update when behaviour or pipelines change |
+| **`apps/*/README.md`**                                                                    | Commands for that app (build, dev, deploy)               |
+| **[README.md](https://github.com/teofanis/ybdownloader/blob/main/README.md)**             | User-facing intro and getting started                    |
+| **[CONTRIBUTING.md](https://github.com/teofanis/ybdownloader/blob/main/CONTRIBUTING.md)** | PRs, branches, local setup                               |
+
+Don't duplicate build commands here — they drift. Link to the app README instead.
+
+## Keeping docs in sync
+
+| You changed…                              | Update…                                                                    |
+| ----------------------------------------- | -------------------------------------------------------------------------- |
+| Web caching, `live.json`, deploy          | [[Architecture-Web]] + `apps/web/README.md`                                |
+| Desktop queue, downloader, Wails bindings | [[Architecture-Desktop]]                                                   |
+| Updater or channel logic                  | [[Architecture-Desktop-Updates]] + `packages/shared/src/releases.ts`       |
+| Extension UI or deep link format          | [[Architecture-Extension-Deep-Links]] + `packages/shared/src/deep-link.ts` |
+| Workflows, tags, release process          | [[Architecture-Releases-and-CI]]                                           |
+
+Copy updated `docs/wiki/*.md` to the [GitHub Wiki](https://github.com/teofanis/ybdownloader/wiki) when you want it public.
+
+## App READMEs
+
+- [Web](https://github.com/teofanis/ybdownloader/blob/main/apps/web/README.md)
+- [Desktop packaging](https://github.com/teofanis/ybdownloader/blob/main/apps/desktop/build/README.md)
+- [Extension](https://github.com/teofanis/ybdownloader/blob/main/apps/extension/README.md)
+- [E2E tests](https://github.com/teofanis/ybdownloader/blob/main/apps/e2e/README.md)

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,0 +1,10 @@
+**[[Home]]**
+
+---
+
+- [[Architecture-Monorepo]]
+- [[Architecture-Web]]
+- [[Architecture-Desktop]]
+- [[Architecture-Desktop-Updates]]
+- [[Architecture-Extension-Deep-Links]]
+- [[Architecture-Releases-and-CI]]


### PR DESCRIPTION
- Added a new `docs/README.md` file to provide an overview of the developer documentation structure.
- Created multiple architecture documentation files in `docs/wiki/` covering Desktop, Web, Extension, Monorepo, and Releases & CI.
- Included Mermaid diagrams to illustrate architecture flows and processes.
- Updated the main `README.md` to link to the new architecture documentation.
- Introduced a sidebar in the wiki for easy navigation between architecture pages.
